### PR TITLE
Remove legacy routes in vercel.json.

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,0 @@
-{
-    "version": 2,
-    "routes": [
-      { "src": "/produkt/(?<slug>[^/]+)$", "dest": "/produkt?slug=$slug" }      
-    ]
-  }
-  


### PR DESCRIPTION
WARNING: your application is being opted out of @vercel/next's optimized lambdas mode due to legacy routes in vercel.json. http://err.sh/vercel/vercel/next-legacy-routes-optimized-lambdas