### PR TITLE
Add ignore-scripts and Renovate min release age

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 legacy-peer-deps=true
+ignore-scripts=true

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,11 @@
 {
-  "extends": ["config:recommended"],
-  "ignorePresets": [":prHourlyLimit2", ":prConcurrentLimit20"],
+  "extends": [
+    "config:recommended"
+  ],
+  "ignorePresets": [
+    ":prHourlyLimit2",
+    ":prConcurrentLimit20"
+  ],
   "packageRules": [
     {
       "rangeStrategy": "bump",
@@ -12,7 +17,11 @@
       ]
     },
     {
-      "matchUpdateTypes": ["minor", "pin", "digest"],
+      "matchUpdateTypes": [
+        "minor",
+        "pin",
+        "digest"
+      ],
       "automerge": true,
       "matchDepTypes": [
         "dependencies",
@@ -22,7 +31,10 @@
       ]
     },
     {
-      "matchUpdateTypes": ["patch", "lockFileMaintenance"],
+      "matchUpdateTypes": [
+        "patch",
+        "lockFileMaintenance"
+      ],
       "automerge": true,
       "automergeType": "branch",
       "matchDepTypes": [
@@ -32,5 +44,6 @@
         "peerDependencies"
       ]
     }
-  ]
+  ],
+  "minimumReleaseAge": "3 days"
 }


### PR DESCRIPTION
Add ignore-scripts to .npmrc to prevent running package lifecycle scripts during install. Reformat arrays in renovate.json for readability and add minimumReleaseAge of 3 days so Renovate delays releases for a short stabilization window.