### PR TITLE
Add pnpm onlyBuiltDependencies to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,5 +62,8 @@
     "react-doctor": "^0.0.37",
     "tailwindcss": "^3.4.19",
     "typescript": "^5.9.3"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": ["sharp", "unrs-resolver"]
   }
 }


### PR DESCRIPTION
- Add a pnpm config entry to package.json listing onlyBuiltDependencies: ["sharp", "unrs-resolver"]. This tells pnpm to only build these native modules during install, which can reduce unnecessary native builds and speed up installation in environments where building binaries is costly.