### PR TITLE
Bump algoliasearch to 5.53.0 and update imports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@apollo/client": "^3.14.1",
         "@types/react": "^19.2.15",
-        "algoliasearch": "^4.27.0",
+        "algoliasearch": "^5.53.0",
         "autoprefixer": "^10.5.0",
         "graphql": "^16.14.0",
         "lodash": "^4.18.1",
@@ -44,83 +44,118 @@
         "typescript": "^6.0.3"
       }
     },
-    "node_modules/@algolia/cache-browser-local-storage": {
-      "version": "4.27.0",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.27.0.tgz",
-      "integrity": "sha512-YGog2s57sO20lvpa+hv5XLAAmiTI1kHsCMRtPVfiaOdIQnvRla21lfH08onqEbZihOPVI8GULwt79zQB2ymKzg==",
+    "node_modules/@algolia/abtesting": {
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/@algolia/abtesting/-/abtesting-1.19.0.tgz",
+      "integrity": "sha512-Lhnez3hhXHk25lfxLAMxvkP4fmN3+1RgADhD2ssMDBYuAsDVReeyP+3SGRx+ntq8ijMrLqUyfvO72TB6jsTteQ==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/cache-common": "4.27.0"
+        "@algolia/client-common": "5.53.0",
+        "@algolia/requester-browser-xhr": "5.53.0",
+        "@algolia/requester-fetch": "5.53.0",
+        "@algolia/requester-node-http": "5.53.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
       }
     },
-    "node_modules/@algolia/cache-common": {
-      "version": "4.27.0",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-common/-/cache-common-4.27.0.tgz",
-      "integrity": "sha512-Sr8zjNXj82p6lO4W9CdzfF0m0/9h/H6VAdSHOTtimm/cTzXIYXRI2IZq7+Nt2ljJ7Ukx+7dIFcxQjE57eQSPsw==",
-      "license": "MIT"
-    },
-    "node_modules/@algolia/cache-in-memory": {
-      "version": "4.27.0",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-in-memory/-/cache-in-memory-4.27.0.tgz",
-      "integrity": "sha512-abgMRTcVD0IllNvMM9JFhxtyLn1v6Ey7mQ7+BGS3JCzvkCX7KZqlS0BIuVUDgx9sPIfOeNsG/awGzMmP50TwZw==",
+    "node_modules/@algolia/client-abtesting": {
+      "version": "5.53.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-abtesting/-/client-abtesting-5.53.0.tgz",
+      "integrity": "sha512-0ZjA5Hcmaoz5Lj6OG0zhfIyeqzJZnLW2CRJA1W17UwMFGRtZAJ9yJKRvPEDA6gkpsIoQxORTSW6sWFiuYncPNQ==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/cache-common": "4.27.0"
-      }
-    },
-    "node_modules/@algolia/client-account": {
-      "version": "4.27.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-account/-/client-account-4.27.0.tgz",
-      "integrity": "sha512-sSHxwrKTKJrwfoR/LcQJZfmiWJcM5d9Rp7afMChxOcdGdkSdIwrNBC8SCcHRenA3GsZ6mg+j6px7KWYxJ34btA==",
-      "license": "MIT",
-      "dependencies": {
-        "@algolia/client-common": "4.27.0",
-        "@algolia/client-search": "4.27.0",
-        "@algolia/transporter": "4.27.0"
+        "@algolia/client-common": "5.53.0",
+        "@algolia/requester-browser-xhr": "5.53.0",
+        "@algolia/requester-fetch": "5.53.0",
+        "@algolia/requester-node-http": "5.53.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-analytics": {
-      "version": "4.27.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-4.27.0.tgz",
-      "integrity": "sha512-MqIDyxODljn9ZC4oqjQD0kez2a4zjIJ9ywA/b7cIiUiK/tDjZNTVjYd9WXMKQlXnWUwfrfXJZClVVqN1iCXS+Q==",
+      "version": "5.53.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-5.53.0.tgz",
+      "integrity": "sha512-kWNodP75iiEaOtemC9F/hlxNBG5E2QUjN1BusnE6m2b4l7Qh/BUO3fGCVsmKJI65VO4VKGGmT43ICvHtTcJ2JQ==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "4.27.0",
-        "@algolia/client-search": "4.27.0",
-        "@algolia/requester-common": "4.27.0",
-        "@algolia/transporter": "4.27.0"
+        "@algolia/client-common": "5.53.0",
+        "@algolia/requester-browser-xhr": "5.53.0",
+        "@algolia/requester-fetch": "5.53.0",
+        "@algolia/requester-node-http": "5.53.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-common": {
-      "version": "4.27.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.27.0.tgz",
-      "integrity": "sha512-ZrT6l/YPQgyIUuBCxcYPeXol2VBLUMuNb1rKXrm6z1f/iTiwqtnEEb16/6CC11+Re0ZGXrdcMVrgDRrzveQ1aQ==",
+      "version": "5.53.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.53.0.tgz",
+      "integrity": "sha512-YPN45TXD9Wrse185t/Ta7nktZsqpv97oOjCzp2sblHnCL6rBc9TDeJAg1IGl2UpdwnSD05Zu/5wLB4watOUMyg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-insights": {
+      "version": "5.53.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-insights/-/client-insights-5.53.0.tgz",
+      "integrity": "sha512-qAcYTDJE6m924FDDUQvdD6vh7DYaqOeSpFS74IP37/JRV0v4cGBauyxTF2WzDnokUylQDbqreoFIJZfg0Fitmw==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/requester-common": "4.27.0",
-        "@algolia/transporter": "4.27.0"
+        "@algolia/client-common": "5.53.0",
+        "@algolia/requester-browser-xhr": "5.53.0",
+        "@algolia/requester-fetch": "5.53.0",
+        "@algolia/requester-node-http": "5.53.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-personalization": {
-      "version": "4.27.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-4.27.0.tgz",
-      "integrity": "sha512-OZqaFFVm+10hAlmxpiTWi/o2n+YKBESbSqSy2yXAumPH/kaK4moJHFblbh8IkV3KZR0lLm4hzPtn8Q2nWNiDUA==",
+      "version": "5.53.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-5.53.0.tgz",
+      "integrity": "sha512-fQaY+DkSJOpuUVUe8MQTwrdiKAqkJGhpDarB08duBn/sUv7Bkib6MDRQauCcWTWTe4HIW+EbwQP9R4kci1V/Yw==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "4.27.0",
-        "@algolia/requester-common": "4.27.0",
-        "@algolia/transporter": "4.27.0"
+        "@algolia/client-common": "5.53.0",
+        "@algolia/requester-browser-xhr": "5.53.0",
+        "@algolia/requester-fetch": "5.53.0",
+        "@algolia/requester-node-http": "5.53.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-query-suggestions": {
+      "version": "5.53.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-query-suggestions/-/client-query-suggestions-5.53.0.tgz",
+      "integrity": "sha512-o72tsiEZGfeS/dxL9IADfzcZWGEwKDEe5CvtrBuT//3JR+SHuTtHRI2ZTf7D7bcKagcbojvO8hnkHdfoakSlYg==",
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.53.0",
+        "@algolia/requester-browser-xhr": "5.53.0",
+        "@algolia/requester-fetch": "5.53.0",
+        "@algolia/requester-node-http": "5.53.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-search": {
-      "version": "4.27.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.27.0.tgz",
-      "integrity": "sha512-qmX/f67ay0eZ4V5Io8fWWOcUVo/gqre2yei1PnmEhQU2Gul6ushg25QnNrfu4BODiRrw1rwYveZaLCiHvcUxrQ==",
+      "version": "5.53.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.53.0.tgz",
+      "integrity": "sha512-Ds16IyPm/dNJPCU8OzApo2gwGrgWT5BYHhE3NFwZbpCveqyvPDB9sZDDkJ5DsdOGT2aC+R3i0/M1OVXF2qdgPg==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "4.27.0",
-        "@algolia/requester-common": "4.27.0",
-        "@algolia/transporter": "4.27.0"
+        "@algolia/client-common": "5.53.0",
+        "@algolia/requester-browser-xhr": "5.53.0",
+        "@algolia/requester-fetch": "5.53.0",
+        "@algolia/requester-node-http": "5.53.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/events": {
@@ -128,73 +163,85 @@
       "resolved": "https://registry.npmjs.org/@algolia/events/-/events-4.0.1.tgz",
       "integrity": "sha512-FQzvOCgoFXAbf5Y6mYozw2aj5KCJoA3m4heImceldzPSMbdyS4atVjJzXKMsfX3wnZTFYwkkt8/z8UesLHlSBQ=="
     },
-    "node_modules/@algolia/logger-common": {
-      "version": "4.27.0",
-      "resolved": "https://registry.npmjs.org/@algolia/logger-common/-/logger-common-4.27.0.tgz",
-      "integrity": "sha512-pIrmQRXtDV+zTMVXKtKCosC2rWhn0F0TdUeb9etA6RiAz6jY6bY6f0+JX7YekDK09SnmZMLIyUa7Jci+Ied9bw==",
-      "license": "MIT"
-    },
-    "node_modules/@algolia/logger-console": {
-      "version": "4.27.0",
-      "resolved": "https://registry.npmjs.org/@algolia/logger-console/-/logger-console-4.27.0.tgz",
-      "integrity": "sha512-UWvta8BxsR/u5z9eI088mOSLQaGtmoCtXeN3DYJurlxAdJwPuKtEb5+433kxA6/E9f2/JgoW89KZ1vNP9pcHBQ==",
+    "node_modules/@algolia/ingestion": {
+      "version": "1.53.0",
+      "resolved": "https://registry.npmjs.org/@algolia/ingestion/-/ingestion-1.53.0.tgz",
+      "integrity": "sha512-oNbT6z4NwD8Pou9VPINGlN/tlG1afESh2EbxqnP6rwl95xKVD/Zlciis1PpNeO/9U/rrajc1+7DcfKi03tX1KQ==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/logger-common": "4.27.0"
+        "@algolia/client-common": "5.53.0",
+        "@algolia/requester-browser-xhr": "5.53.0",
+        "@algolia/requester-fetch": "5.53.0",
+        "@algolia/requester-node-http": "5.53.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/monitoring": {
+      "version": "1.53.0",
+      "resolved": "https://registry.npmjs.org/@algolia/monitoring/-/monitoring-1.53.0.tgz",
+      "integrity": "sha512-G+KZb/yd+qAOFn/cEvTGeLxQm8aP3a0od50l3z/ylccY+/o4YG3TNcjU1tFQHW4mXC137GPyR7W70R0kRQDLnA==",
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.53.0",
+        "@algolia/requester-browser-xhr": "5.53.0",
+        "@algolia/requester-fetch": "5.53.0",
+        "@algolia/requester-node-http": "5.53.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/recommend": {
-      "version": "4.27.0",
-      "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-4.27.0.tgz",
-      "integrity": "sha512-CFy54xDjrsazPi3KN04yPmLRDT72AKokc3RLOdWQvG0/uEUjj7dhWqe9qenxpL4ydsjO7S1eY5YqmX+uMGonlg==",
+      "version": "5.53.0",
+      "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-5.53.0.tgz",
+      "integrity": "sha512-6aVfYd55Un6IUgPLbo84WfgFZlS3L0vA1ttzXL5vahHewUJ8jYgd89TzlWRTeej7w70mb9RWsVlFYGmJ/diQww==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/cache-browser-local-storage": "4.27.0",
-        "@algolia/cache-common": "4.27.0",
-        "@algolia/cache-in-memory": "4.27.0",
-        "@algolia/client-common": "4.27.0",
-        "@algolia/client-search": "4.27.0",
-        "@algolia/logger-common": "4.27.0",
-        "@algolia/logger-console": "4.27.0",
-        "@algolia/requester-browser-xhr": "4.27.0",
-        "@algolia/requester-common": "4.27.0",
-        "@algolia/requester-node-http": "4.27.0",
-        "@algolia/transporter": "4.27.0"
+        "@algolia/client-common": "5.53.0",
+        "@algolia/requester-browser-xhr": "5.53.0",
+        "@algolia/requester-fetch": "5.53.0",
+        "@algolia/requester-node-http": "5.53.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/requester-browser-xhr": {
-      "version": "4.27.0",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.27.0.tgz",
-      "integrity": "sha512-dTenMBIIpyp5o3C2ZnfbsuSlD/lL9jPkk6T+2+qm38fyw2nf49ANbcHFE79NgiGrnmw7QrYveCs9NIP3Wk4v6g==",
+      "version": "5.53.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.53.0.tgz",
+      "integrity": "sha512-ke27DqgzCOlt+RbeEdCxtXxMQOnAOi8ujr2wid0DmDKzR95Kw/f9sBsuhBxtjevCqJRJszfRTLY0B1pbO6IhkA==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/requester-common": "4.27.0"
+        "@algolia/client-common": "5.53.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
       }
     },
-    "node_modules/@algolia/requester-common": {
-      "version": "4.27.0",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-common/-/requester-common-4.27.0.tgz",
-      "integrity": "sha512-VC3prAQVgWTubMStb3mJz6i61Hqbtagi2LeIbgNtoFJFff3XZDcAaO1D5r0GYl2+DrB2VzUHnQXbkiuI+HHYyg==",
-      "license": "MIT"
+    "node_modules/@algolia/requester-fetch": {
+      "version": "5.53.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-fetch/-/requester-fetch-5.53.0.tgz",
+      "integrity": "sha512-GngiOqt2Gq4oLno6yXQVj9om+qSO9SWAoduoTOEg79dKZ62brB8OOIvSJG/vDNoanYi6a7Al9uDZwXvi+bcVTg==",
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.53.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
     },
     "node_modules/@algolia/requester-node-http": {
-      "version": "4.27.0",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.27.0.tgz",
-      "integrity": "sha512-y8nUqaUQeSOQ5oaNo0b2QPznyBFW9LoIwljyUphJ+gUZpU6O/j2/C8ovoqDpIe6J0etqHg5RCcBizrCFZuLpyw==",
+      "version": "5.53.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.53.0.tgz",
+      "integrity": "sha512-6mF9LZMUk0QqWvrnxkxBqhswwz6Xfiwy6/gmTzL5HrlhdVG3ITAqGV2k3XmVThP1h0Ulc3VQwiNCD7/Nr4JNlQ==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/requester-common": "4.27.0"
-      }
-    },
-    "node_modules/@algolia/transporter": {
-      "version": "4.27.0",
-      "resolved": "https://registry.npmjs.org/@algolia/transporter/-/transporter-4.27.0.tgz",
-      "integrity": "sha512-PvSbELU4VjN3xSX79ki+zIdOGhTxyJXWvRDzkUjfTx2iNfPWDdTjzKbP1o+268coJztxrkuBwJz90Urek7o1Kw==",
-      "license": "MIT",
-      "dependencies": {
-        "@algolia/cache-common": "4.27.0",
-        "@algolia/logger-common": "4.27.0",
-        "@algolia/requester-common": "4.27.0"
+        "@algolia/client-common": "5.53.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -3278,9 +3325,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3298,9 +3342,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3318,9 +3359,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3338,9 +3376,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3358,9 +3393,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3378,9 +3410,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3398,9 +3427,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3418,9 +3444,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3633,9 +3656,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3650,9 +3670,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3667,9 +3684,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3684,9 +3698,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3701,9 +3712,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3718,9 +3726,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3735,9 +3740,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3752,9 +3754,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3961,9 +3960,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3981,9 +3977,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4001,9 +3994,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4021,9 +4011,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4041,9 +4028,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4061,9 +4045,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4081,9 +4062,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4101,9 +4079,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5511,26 +5486,28 @@
       }
     },
     "node_modules/algoliasearch": {
-      "version": "4.27.0",
-      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.27.0.tgz",
-      "integrity": "sha512-C88C5grLa5VOCp9eYZJt+q99ik7yNdm92l7Q9+4XK0Md8kL05Lg8l2v9ZVX0uMW3mH9pAFxMMXlLOvqNumA4lw==",
+      "version": "5.53.0",
+      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.53.0.tgz",
+      "integrity": "sha512-OGW1q6b91CRSSeiOnM8LxuR5NYJ2esvw66jUZ4IIvdv+ItNkx3pwLuyR+jaCdbGee4ov5WgUnyPryyh11xvByQ==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/cache-browser-local-storage": "4.27.0",
-        "@algolia/cache-common": "4.27.0",
-        "@algolia/cache-in-memory": "4.27.0",
-        "@algolia/client-account": "4.27.0",
-        "@algolia/client-analytics": "4.27.0",
-        "@algolia/client-common": "4.27.0",
-        "@algolia/client-personalization": "4.27.0",
-        "@algolia/client-search": "4.27.0",
-        "@algolia/logger-common": "4.27.0",
-        "@algolia/logger-console": "4.27.0",
-        "@algolia/recommend": "4.27.0",
-        "@algolia/requester-browser-xhr": "4.27.0",
-        "@algolia/requester-common": "4.27.0",
-        "@algolia/requester-node-http": "4.27.0",
-        "@algolia/transporter": "4.27.0"
+        "@algolia/abtesting": "1.19.0",
+        "@algolia/client-abtesting": "5.53.0",
+        "@algolia/client-analytics": "5.53.0",
+        "@algolia/client-common": "5.53.0",
+        "@algolia/client-insights": "5.53.0",
+        "@algolia/client-personalization": "5.53.0",
+        "@algolia/client-query-suggestions": "5.53.0",
+        "@algolia/client-search": "5.53.0",
+        "@algolia/ingestion": "1.53.0",
+        "@algolia/monitoring": "1.53.0",
+        "@algolia/recommend": "5.53.0",
+        "@algolia/requester-browser-xhr": "5.53.0",
+        "@algolia/requester-fetch": "5.53.0",
+        "@algolia/requester-node-http": "5.53.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
       }
     },
     "node_modules/algoliasearch-helper": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "@apollo/client": "^3.14.1",
     "@types/react": "^19.2.15",
-    "algoliasearch": "^4.27.0",
+    "algoliasearch": "^5.53.0",
     "autoprefixer": "^10.5.0",
     "graphql": "^16.14.0",
     "lodash": "^4.18.1",

--- a/src/components/AlgoliaSearch/AlgoliaSearchBox.component.tsx
+++ b/src/components/AlgoliaSearch/AlgoliaSearchBox.component.tsx
@@ -1,4 +1,4 @@
-import algoliasearch from 'algoliasearch';
+import { algoliasearch } from 'algoliasearch';
 import { InstantSearch, SearchBox, Hits } from 'react-instantsearch-dom';
 import { useState } from 'react';
 

--- a/src/components/AlgoliaSearch/MobileSearch.component.tsx
+++ b/src/components/AlgoliaSearch/MobileSearch.component.tsx
@@ -1,4 +1,4 @@
-import algoliasearch from 'algoliasearch';
+import { algoliasearch } from 'algoliasearch';
 import { InstantSearch, SearchBox, Hits } from 'react-instantsearch-dom';
 import { useState } from 'react';
 


### PR DESCRIPTION
Upgrade algoliasearch dependency from ^4.27.0 to ^5.53.0 and regenerate package-lock.json (lockfile now includes Algolia v5 packages and related requester/client modules). Update two components (AlgoliaSearchBox and MobileSearch) to use the named import { algoliasearch } instead of the default import to match the v5 API.