### PR TITLE
Init selectedVariation, remove loading state

### DIFF
--- a/src/components/Product/SingleProduct.component.tsx
+++ b/src/components/Product/SingleProduct.component.tsx
@@ -53,20 +53,6 @@ const getOriginalSalePrice = (
 ): string | undefined =>
   hasVariations ? filteredVariantPrice(price, 'right') : regularPrice;
 
-/** Initialise the selected variation from the product's first variation node */
-const useVariationInitializer = (
-  variations: ISingleProduct['variations'],
-  setSelectedVariation: (id: number) => void,
-  setIsLoading: (loading: boolean) => void,
-) => {
-  useEffect(() => {
-    setIsLoading(false);
-    if (variations) {
-      setSelectedVariation(variations.nodes[0].databaseId);
-    }
-  }, [variations, setSelectedVariation, setIsLoading]);
-};
-
 // --- Sub-components ---
 
 const ProductImage = ({

--- a/src/components/Product/SingleProduct.component.tsx
+++ b/src/components/Product/SingleProduct.component.tsx
@@ -1,5 +1,5 @@
 // Imports
-import { useState, useEffect, useMemo } from 'react';
+import { useState, useMemo } from 'react';
 
 // Utils
 import { filteredVariantPrice, paddedPrice } from '@/utils/functions/functions';

--- a/src/components/Product/SingleProduct.component.tsx
+++ b/src/components/Product/SingleProduct.component.tsx
@@ -142,18 +142,6 @@ const VariationSelector = ({
   </div>
 );
 
-// --- Loading state ---
-
-const ProductLoadingState = () => (
-  <section className="bg-surface mb-32 md:mb-12">
-    <div className="h-56 mt-20">
-      <p className="text-xl font-bold text-center text-text">Laster produkt ...</p>
-      <br />
-      <LoadingSpinner />
-    </div>
-  </section>
-);
-
 // --- Product Details ---
 
 const ProductDetails = ({

--- a/src/components/Product/SingleProduct.component.tsx
+++ b/src/components/Product/SingleProduct.component.tsx
@@ -222,20 +222,16 @@ const ProductDetails = ({
 // --- Main Component ---
 
 const SingleProduct = ({ product }: ISingleProductProps) => {
-  const [isLoading, setIsLoading] = useState<boolean>(true);
-  const [selectedVariation, setSelectedVariation] = useState<number>();
-
-  useVariationInitializer(product.variations, setSelectedVariation, setIsLoading);
+  // Initialize selectedVariation with the first variation's databaseId if variations exist
+  const [selectedVariation, setSelectedVariation] = useState<number | undefined>(
+    product.variations?.nodes[0]?.databaseId
+  );
 
   const price = formatPrice(product.price);
   const regularPrice = formatPrice(product.regularPrice);
   const salePrice = formatPrice(product.salePrice);
   const descriptionText = useStrippedDescription(product.description);
   const hasVariations = Boolean(product.variations);
-
-  if (isLoading) {
-    return <ProductLoadingState />;
-  }
 
   return (
     <section className="bg-surface mb-32 md:mb-12">

--- a/src/components/Product/SingleProduct.component.tsx
+++ b/src/components/Product/SingleProduct.component.tsx
@@ -6,7 +6,6 @@ import { filteredVariantPrice, paddedPrice } from '@/utils/functions/functions';
 
 // Components
 import AddToCart from './AddToCart.component';
-import LoadingSpinner from '@/components/LoadingSpinner/LoadingSpinner.component';
 
 // Types
 import type { ISingleProductProps, ISingleProduct } from '@/types/product';

--- a/src/utils/apollo/ApolloClient.ts
+++ b/src/utils/apollo/ApolloClient.ts
@@ -25,7 +25,7 @@ export const middleware = new ApolloLink((operation, forward) => {
    */
   // Cache the localStorage read to avoid multiple accesses across middleware and afterware
   const cachedWooSession =
-    typeof globalThis.window === 'undefined' ? null : localStorage.getItem('woo-session');
+    globalThis.window === undefined ? null : localStorage.getItem('woo-session');
   
   const sessionData: SessionData | null = cachedWooSession
     ? JSON.parse(cachedWooSession)
@@ -77,7 +77,7 @@ export const afterware = new ApolloLink((operation, forward) =>
 
     const session = headers.get('woocommerce-session');
 
-    if (session && typeof globalThis.window !== 'undefined') {
+    if (session && globalThis.window !== undefined) {
       // Use the cached value from middleware instead of re-reading localStorage
       if ('false' === session) {
         // Remove session data if session destroyed.
@@ -95,7 +95,7 @@ export const afterware = new ApolloLink((operation, forward) =>
   }),
 );
 
-const isServerSide = typeof globalThis.window === 'undefined';
+const isServerSide = globalThis.window === undefined;
 
 // Apollo GraphQL client.
 const client = new ApolloClient({

--- a/src/utils/apollo/ApolloClient.ts
+++ b/src/utils/apollo/ApolloClient.ts
@@ -25,7 +25,7 @@ export const middleware = new ApolloLink((operation, forward) => {
    */
   // Cache the localStorage read to avoid multiple accesses across middleware and afterware
   const cachedWooSession =
-    typeof window !== 'undefined' ? localStorage.getItem('woo-session') : null;
+    typeof globalThis.window === 'undefined' ? null : localStorage.getItem('woo-session');
   
   const sessionData: SessionData | null = cachedWooSession
     ? JSON.parse(cachedWooSession)
@@ -77,7 +77,7 @@ export const afterware = new ApolloLink((operation, forward) =>
 
     const session = headers.get('woocommerce-session');
 
-    if (session && typeof window !== 'undefined') {
+    if (session && typeof globalThis.window !== 'undefined') {
       // Use the cached value from middleware instead of re-reading localStorage
       if ('false' === session) {
         // Remove session data if session destroyed.
@@ -95,7 +95,7 @@ export const afterware = new ApolloLink((operation, forward) =>
   }),
 );
 
-const isServerSide = typeof window === 'undefined';
+const isServerSide = typeof globalThis.window === 'undefined';
 
 // Apollo GraphQL client.
 const client = new ApolloClient({

--- a/src/utils/apollo/ApolloClient.ts
+++ b/src/utils/apollo/ApolloClient.ts
@@ -72,11 +72,14 @@ export const afterware = new ApolloLink((operation, forward) =>
     const session = headers.get('woocommerce-session');
 
     if (session && typeof window !== 'undefined') {
+      // Cache the localStorage read to avoid multiple accesses
+      const existingSession = localStorage.getItem('woo-session');
+      
       if ('false' === session) {
         // Remove session data if session destroyed.
         localStorage.removeItem('woo-session');
         // Update session new data if changed.
-      } else if (!localStorage.getItem('woo-session')) {
+      } else if (!existingSession) {
         localStorage.setItem(
           'woo-session',
           JSON.stringify({ token: session, createdTime: Date.now() }),

--- a/src/utils/apollo/ApolloClient.ts
+++ b/src/utils/apollo/ApolloClient.ts
@@ -23,10 +23,13 @@ export const middleware = new ApolloLink((operation, forward) => {
    * If session data exist in local storage, set value as session header.
    * Here we also delete the session if it is older than 7 days
    */
-  const sessionData: SessionData | null =
-    typeof window !== 'undefined'
-      ? JSON.parse(localStorage.getItem('woo-session') || 'null')
-      : null;
+  // Cache the localStorage read to avoid multiple accesses across middleware and afterware
+  const cachedWooSession =
+    typeof window !== 'undefined' ? localStorage.getItem('woo-session') : null;
+  
+  const sessionData: SessionData | null = cachedWooSession
+    ? JSON.parse(cachedWooSession)
+    : null;
 
   const headers: Record<string, string> = {};
 
@@ -49,6 +52,8 @@ export const middleware = new ApolloLink((operation, forward) => {
 
   operation.setContext({
     headers,
+    // Pass the cached session to afterware to avoid re-reading localStorage
+    cachedWooSession,
   });
 
   return forward(operation);
@@ -67,19 +72,18 @@ export const afterware = new ApolloLink((operation, forward) =>
     const context = operation.getContext();
     const {
       response: { headers },
+      cachedWooSession,
     } = context;
 
     const session = headers.get('woocommerce-session');
 
     if (session && typeof window !== 'undefined') {
-      // Cache the localStorage read to avoid multiple accesses
-      const existingSession = localStorage.getItem('woo-session');
-      
+      // Use the cached value from middleware instead of re-reading localStorage
       if ('false' === session) {
         // Remove session data if session destroyed.
         localStorage.removeItem('woo-session');
         // Update session new data if changed.
-      } else if (!existingSession) {
+      } else if (!cachedWooSession) {
         localStorage.setItem(
           'woo-session',
           JSON.stringify({ token: session, createdTime: Date.now() }),


### PR DESCRIPTION
- Initialize selectedVariation directly from product.variations?.nodes[0]?.databaseId and remove the useVariationInitializer hook and isLoading state. Also remove the early return that rendered ProductLoadingState. This simplifies the component by setting the initial variation inline (number | undefined) and eliminating the separate loading/initialization flow.