### PR TITLE
Remove checked attribute from hidden input

### DIFF
--- a/src/components/Checkout/Billing.component.tsx
+++ b/src/components/Checkout/Billing.component.tsx
@@ -29,7 +29,6 @@ const OrderButton = () => {
         placeholder="paymentMethod"
         type="hidden"
         value="cod"
-        checked
         {...register('paymentMethod')}
       />
       <div className="mt-4 flex justify-center">


### PR DESCRIPTION
Remove the stray `checked` prop from the hidden `paymentMethod` input. Hidden inputs do not support `checked` and the prop was unnecessary — removing it prevents React warnings and avoids potential interference with form state while keeping the default value of `cod`.