### PR TITLE
CI: add --ignore-scripts to pnpm install

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -29,7 +29,7 @@ jobs:
             ${{ runner.os }}-pnpm-store-
 
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --ignore-scripts
 
       - name: Build project
         env:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -17,7 +17,7 @@ jobs:
         node-version: 24
         cache: 'pnpm'
     - name: Install dependencies
-      run: pnpm install --frozen-lockfile
+      run: pnpm install --frozen-lockfile --ignore-scripts
     - name: Install Playwright Browsers
       run: pnpm exec playwright install --with-deps
     - name: Build the project


### PR DESCRIPTION
Add --ignore-scripts to pnpm install in .github/workflows/lighthouse.yml and .github/workflows/playwright.yml to prevent running package lifecycle scripts during CI installs. In the Playwright workflow the browsers are still installed explicitly via `pnpm exec playwright install --with-deps`; the frozen lockfile behavior is preserved. This hardens and speeds up the CI environment by avoiding unintended postinstall behavior.