### PR TITLE
Use next/image

### DIFF
--- a/src/components/AlgoliaSearch/SearchResults.component.tsx
+++ b/src/components/AlgoliaSearch/SearchResults.component.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link';
+import Image from 'next/image';
 import { trimmedStringToLength } from '@/utils/functions/functions';
 
 interface ISearchResultProps {
@@ -41,11 +42,13 @@ const SearchResults = ({
         passHref
       >
         <div className="flex p-6 bg-surface">
-          <header className="hit-image-container">
-            <img
+          <header className="hit-image-container relative w-12 h-12">
+            <Image
               src={product_image}
               alt={product_name}
-              className="w-12 hit-image"
+              fill
+              sizes="48px"
+              className="hit-image object-cover"
             />
           </header>
           <div className="pl-4 text-left">

--- a/src/components/Product/DisplayProducts.component.tsx
+++ b/src/components/Product/DisplayProducts.component.tsx
@@ -1,5 +1,6 @@
 /*eslint complexity: ["error", 20]*/
 import Link from 'next/link';
+import Image from 'next/image';
 
 import { filteredVariantPrice, paddedPrice } from '@/utils/functions/functions';
 
@@ -51,20 +52,22 @@ const DisplayProducts = ({ products }: IDisplayProductsProps) => (
                 <Link href={`/produkt/${encodeURIComponent(slug)}`}>
                   <div className="aspect-[3/4] relative overflow-hidden bg-surface-alt">
                     {image ? (
-                      <img
+                      <Image
                         id="product-image"
-                        className="w-full h-full object-cover object-center transition duration-300 group-hover:scale-105"
+                        className="object-cover object-center transition duration-300 group-hover:scale-105"
                         alt={name}
-                        src={image.sourceUrl}
+                        src={image.sourceUrl || process.env.NEXT_PUBLIC_PLACEHOLDER_SMALL_IMAGE_URL || ''}
+                        fill
+                        sizes="(max-width: 768px) 100vw, (max-width: 1024px) 50vw, (max-width: 1280px) 33vw, 25vw"
                       />
                     ) : (
-                      <img
+                      <Image
                         id="product-image"
-                        className="w-full h-full object-cover object-center transition duration-300 group-hover:scale-105"
+                        className="object-cover object-center transition duration-300 group-hover:scale-105"
                         alt={name}
-                        src={
-                          process.env.NEXT_PUBLIC_PLACEHOLDER_SMALL_IMAGE_URL
-                        }
+                        src={process.env.NEXT_PUBLIC_PLACEHOLDER_SMALL_IMAGE_URL || ''}
+                        fill
+                        sizes="(max-width: 768px) 100vw, (max-width: 1024px) 50vw, (max-width: 1280px) 33vw, 25vw"
                       />
                     )}
                   </div>

--- a/src/components/Product/SingleProduct.component.tsx
+++ b/src/components/Product/SingleProduct.component.tsx
@@ -1,5 +1,6 @@
 // Imports
 import { useState, useMemo } from 'react';
+import Image from 'next/image';
 
 // Utils
 import { filteredVariantPrice, paddedPrice } from '@/utils/functions/functions';
@@ -63,11 +64,13 @@ const ProductImage = ({
 }) => (
   <div className="mb-6 md:mb-0 group">
     <div className="max-w-xl mx-auto aspect-[3/4] relative overflow-hidden bg-surface-alt">
-      <img
+      <Image
         id="product-image"
         src={getImageSrc(image)}
         alt={alt}
-        className="w-full h-full object-cover object-center transition duration-300 group-hover:scale-105"
+        fill
+        sizes="(max-width: 768px) 100vw, 672px"
+        className="object-cover object-center transition duration-300 group-hover:scale-105"
       />
     </div>
   </div>


### PR DESCRIPTION
- Replace native <img> with Next.js Image in SearchResults to enable image optimization. Added Image import and updated header container to be positioned and sized (relative w-12 h-12), used fill and sizes props plus object-cover styling to preserve layout and cropping. This improves performance and consistent thumbnail rendering.