### PR TITLE
Use non-null env vars for Algolia client

### DIFF
--- a/src/components/AlgoliaSearch/AlgoliaSearchBox.component.tsx
+++ b/src/components/AlgoliaSearch/AlgoliaSearchBox.component.tsx
@@ -2,7 +2,7 @@ import { InstantSearch, SearchBox, Hits } from 'react-instantsearch-dom';
 import { useState } from 'react';
 
 import SearchResults from './SearchResults.component';
-import { searchClient, indexName } from '@/utils/algolia/config';
+import { getSearchClient, indexName, isAlgoliaConfigured } from '@/utils/algolia/config';
 
 // https://www.algolia.com/doc/api-reference/widgets/instantsearch/react/
 
@@ -12,6 +12,17 @@ import { searchClient, indexName } from '@/utils/algolia/config';
 const AlgoliaSearchBox = () => {
   const [search, setSearch] = useState<string | null>(null);
   const [hasFocus, sethasFocus] = useState<boolean>(false);
+
+  // Don't render if Algolia is not configured
+  if (!isAlgoliaConfigured) {
+    return null;
+  }
+
+  const searchClient = getSearchClient();
+
+  if (!searchClient) {
+    return null;
+  }
 
   return (
     <div className="hidden mb-0.5 md:inline xl:inline">

--- a/src/components/AlgoliaSearch/AlgoliaSearchBox.component.tsx
+++ b/src/components/AlgoliaSearch/AlgoliaSearchBox.component.tsx
@@ -4,28 +4,10 @@ import { useState } from 'react';
 
 import SearchResults from './SearchResults.component';
 
-// Validate required environment variables
-const ALGOLIA_APP_ID = process.env.NEXT_PUBLIC_ALGOLIA_APP_ID;
-const ALGOLIA_API_KEY = process.env.NEXT_PUBLIC_ALGOLIA_PUBLIC_API_KEY;
-const ALGOLIA_INDEX_NAME = process.env.NEXT_PUBLIC_ALGOLIA_INDEX_NAME;
-
-if (!ALGOLIA_APP_ID) {
-  throw new Error(
-    'NEXT_PUBLIC_ALGOLIA_APP_ID environment variable is required',
-  );
-}
-if (!ALGOLIA_API_KEY) {
-  throw new Error(
-    'NEXT_PUBLIC_ALGOLIA_PUBLIC_API_KEY environment variable is required',
-  );
-}
-if (!ALGOLIA_INDEX_NAME) {
-  throw new Error(
-    'NEXT_PUBLIC_ALGOLIA_INDEX_NAME environment variable is required',
-  );
-}
-
-const searchClient = algoliasearch(ALGOLIA_APP_ID, ALGOLIA_API_KEY);
+const searchClient = algoliasearch(
+  process.env.NEXT_PUBLIC_ALGOLIA_APP_ID || '',
+  process.env.NEXT_PUBLIC_ALGOLIA_PUBLIC_API_KEY || '',
+);
 
 // https://www.algolia.com/doc/api-reference/widgets/instantsearch/react/
 
@@ -36,11 +18,23 @@ const AlgoliaSearchBox = () => {
   const [search, setSearch] = useState<string | null>(null);
   const [hasFocus, sethasFocus] = useState<boolean>(false);
 
+  if (process.env.NODE_ENV === 'development') {
+    if (!process.env.NEXT_PUBLIC_ALGOLIA_APP_ID) {
+      console.warn('AlgoliaSearchBox: NEXT_PUBLIC_ALGOLIA_APP_ID is not configured');
+    }
+    if (!process.env.NEXT_PUBLIC_ALGOLIA_PUBLIC_API_KEY) {
+      console.warn('AlgoliaSearchBox: NEXT_PUBLIC_ALGOLIA_PUBLIC_API_KEY is not configured');
+    }
+    if (!process.env.NEXT_PUBLIC_ALGOLIA_INDEX_NAME) {
+      console.warn('AlgoliaSearchBox: NEXT_PUBLIC_ALGOLIA_INDEX_NAME is not configured');
+    }
+  }
+
   return (
     <div className="hidden mb-0.5 md:inline xl:inline">
       <div className="">
         <InstantSearch
-          indexName={ALGOLIA_INDEX_NAME}
+          indexName={process.env.NEXT_PUBLIC_ALGOLIA_INDEX_NAME || ''}
           searchClient={searchClient}
         >
           {/*We need to conditionally add a border because the element has position:fixed*/}

--- a/src/components/AlgoliaSearch/AlgoliaSearchBox.component.tsx
+++ b/src/components/AlgoliaSearch/AlgoliaSearchBox.component.tsx
@@ -4,10 +4,28 @@ import { useState } from 'react';
 
 import SearchResults from './SearchResults.component';
 
-const searchClient = algoliasearch(
-  process.env.NEXT_PUBLIC_ALGOLIA_APP_ID!,
-  process.env.NEXT_PUBLIC_ALGOLIA_PUBLIC_API_KEY!,
-);
+// Validate required environment variables
+const ALGOLIA_APP_ID = process.env.NEXT_PUBLIC_ALGOLIA_APP_ID;
+const ALGOLIA_API_KEY = process.env.NEXT_PUBLIC_ALGOLIA_PUBLIC_API_KEY;
+const ALGOLIA_INDEX_NAME = process.env.NEXT_PUBLIC_ALGOLIA_INDEX_NAME;
+
+if (!ALGOLIA_APP_ID) {
+  throw new Error(
+    'NEXT_PUBLIC_ALGOLIA_APP_ID environment variable is required',
+  );
+}
+if (!ALGOLIA_API_KEY) {
+  throw new Error(
+    'NEXT_PUBLIC_ALGOLIA_PUBLIC_API_KEY environment variable is required',
+  );
+}
+if (!ALGOLIA_INDEX_NAME) {
+  throw new Error(
+    'NEXT_PUBLIC_ALGOLIA_INDEX_NAME environment variable is required',
+  );
+}
+
+const searchClient = algoliasearch(ALGOLIA_APP_ID, ALGOLIA_API_KEY);
 
 // https://www.algolia.com/doc/api-reference/widgets/instantsearch/react/
 
@@ -22,7 +40,7 @@ const AlgoliaSearchBox = () => {
     <div className="hidden mb-0.5 md:inline xl:inline">
       <div className="">
         <InstantSearch
-          indexName={process.env.NEXT_PUBLIC_ALGOLIA_INDEX_NAME!}
+          indexName={ALGOLIA_INDEX_NAME}
           searchClient={searchClient}
         >
           {/*We need to conditionally add a border because the element has position:fixed*/}

--- a/src/components/AlgoliaSearch/AlgoliaSearchBox.component.tsx
+++ b/src/components/AlgoliaSearch/AlgoliaSearchBox.component.tsx
@@ -5,8 +5,8 @@ import { useState } from 'react';
 import SearchResults from './SearchResults.component';
 
 const searchClient = algoliasearch(
-  process.env.NEXT_PUBLIC_ALGOLIA_APP_ID ?? 'changeme',
-  process.env.NEXT_PUBLIC_ALGOLIA_PUBLIC_API_KEY ?? 'changeme',
+  process.env.NEXT_PUBLIC_ALGOLIA_APP_ID!,
+  process.env.NEXT_PUBLIC_ALGOLIA_PUBLIC_API_KEY!,
 );
 
 // https://www.algolia.com/doc/api-reference/widgets/instantsearch/react/
@@ -22,7 +22,7 @@ const AlgoliaSearchBox = () => {
     <div className="hidden mb-0.5 md:inline xl:inline">
       <div className="">
         <InstantSearch
-          indexName={process.env.NEXT_PUBLIC_ALGOLIA_INDEX_NAME ?? 'changeme'}
+          indexName={process.env.NEXT_PUBLIC_ALGOLIA_INDEX_NAME!}
           searchClient={searchClient}
         >
           {/*We need to conditionally add a border because the element has position:fixed*/}

--- a/src/components/AlgoliaSearch/AlgoliaSearchBox.component.tsx
+++ b/src/components/AlgoliaSearch/AlgoliaSearchBox.component.tsx
@@ -1,13 +1,8 @@
-import { algoliasearch } from 'algoliasearch';
 import { InstantSearch, SearchBox, Hits } from 'react-instantsearch-dom';
 import { useState } from 'react';
 
 import SearchResults from './SearchResults.component';
-
-const searchClient = algoliasearch(
-  process.env.NEXT_PUBLIC_ALGOLIA_APP_ID || '',
-  process.env.NEXT_PUBLIC_ALGOLIA_PUBLIC_API_KEY || '',
-);
+import { searchClient, indexName } from '@/utils/algolia/config';
 
 // https://www.algolia.com/doc/api-reference/widgets/instantsearch/react/
 
@@ -18,25 +13,10 @@ const AlgoliaSearchBox = () => {
   const [search, setSearch] = useState<string | null>(null);
   const [hasFocus, sethasFocus] = useState<boolean>(false);
 
-  if (process.env.NODE_ENV === 'development') {
-    if (!process.env.NEXT_PUBLIC_ALGOLIA_APP_ID) {
-      console.warn('AlgoliaSearchBox: NEXT_PUBLIC_ALGOLIA_APP_ID is not configured');
-    }
-    if (!process.env.NEXT_PUBLIC_ALGOLIA_PUBLIC_API_KEY) {
-      console.warn('AlgoliaSearchBox: NEXT_PUBLIC_ALGOLIA_PUBLIC_API_KEY is not configured');
-    }
-    if (!process.env.NEXT_PUBLIC_ALGOLIA_INDEX_NAME) {
-      console.warn('AlgoliaSearchBox: NEXT_PUBLIC_ALGOLIA_INDEX_NAME is not configured');
-    }
-  }
-
   return (
     <div className="hidden mb-0.5 md:inline xl:inline">
       <div className="">
-        <InstantSearch
-          indexName={process.env.NEXT_PUBLIC_ALGOLIA_INDEX_NAME || ''}
-          searchClient={searchClient}
-        >
+        <InstantSearch indexName={indexName} searchClient={searchClient}>
           {/*We need to conditionally add a border because the element has position:fixed*/}
           <SearchBox
             aria-label="Søk her"

--- a/src/components/AlgoliaSearch/MobileSearch.component.tsx
+++ b/src/components/AlgoliaSearch/MobileSearch.component.tsx
@@ -1,13 +1,8 @@
-import { algoliasearch } from 'algoliasearch';
 import { InstantSearch, SearchBox, Hits } from 'react-instantsearch-dom';
 import { useState } from 'react';
 
 import SearchResults from './SearchResults.component';
-
-const searchClient = algoliasearch(
-  process.env.NEXT_PUBLIC_ALGOLIA_APP_ID || '',
-  process.env.NEXT_PUBLIC_ALGOLIA_PUBLIC_API_KEY || '',
-);
+import { searchClient, indexName } from '@/utils/algolia/config';
 
 /**
  * Algolia search for mobile menu.
@@ -16,24 +11,9 @@ const MobileSearch = () => {
   const [search, setSearch] = useState<string | null>(null);
   const [hasFocus, sethasFocus] = useState<boolean>(false);
 
-  if (process.env.NODE_ENV === 'development') {
-    if (!process.env.NEXT_PUBLIC_ALGOLIA_APP_ID) {
-      console.warn('MobileSearch: NEXT_PUBLIC_ALGOLIA_APP_ID is not configured');
-    }
-    if (!process.env.NEXT_PUBLIC_ALGOLIA_PUBLIC_API_KEY) {
-      console.warn('MobileSearch: NEXT_PUBLIC_ALGOLIA_PUBLIC_API_KEY is not configured');
-    }
-    if (!process.env.NEXT_PUBLIC_ALGOLIA_INDEX_NAME) {
-      console.warn('MobileSearch: NEXT_PUBLIC_ALGOLIA_INDEX_NAME is not configured');
-    }
-  }
-
   return (
     <div className="inline mt-4 md:hidden">
-      <InstantSearch
-        indexName={process.env.NEXT_PUBLIC_ALGOLIA_INDEX_NAME || ''}
-        searchClient={searchClient}
-      >
+      <InstantSearch indexName={indexName} searchClient={searchClient}>
         <SearchBox
           translations={{
             submitTitle: 'Søk',

--- a/src/components/AlgoliaSearch/MobileSearch.component.tsx
+++ b/src/components/AlgoliaSearch/MobileSearch.component.tsx
@@ -5,8 +5,8 @@ import { useState } from 'react';
 import SearchResults from './SearchResults.component';
 
 const searchClient = algoliasearch(
-  process.env.NEXT_PUBLIC_ALGOLIA_APP_ID ?? 'changethis',
-  process.env.NEXT_PUBLIC_ALGOLIA_PUBLIC_API_KEY ?? 'changethis',
+  process.env.NEXT_PUBLIC_ALGOLIA_APP_ID!,
+  process.env.NEXT_PUBLIC_ALGOLIA_PUBLIC_API_KEY!,
 );
 
 /**
@@ -18,7 +18,7 @@ const MobileSearch = () => {
   return (
     <div className="inline mt-4 md:hidden">
       <InstantSearch
-        indexName={process.env.NEXT_PUBLIC_ALGOLIA_INDEX_NAME ?? 'changeme'}
+        indexName={process.env.NEXT_PUBLIC_ALGOLIA_INDEX_NAME!}
         searchClient={searchClient}
       >
         <SearchBox

--- a/src/components/AlgoliaSearch/MobileSearch.component.tsx
+++ b/src/components/AlgoliaSearch/MobileSearch.component.tsx
@@ -4,22 +4,10 @@ import { useState } from 'react';
 
 import SearchResults from './SearchResults.component';
 
-// Validate required environment variables
-const ALGOLIA_APP_ID = process.env.NEXT_PUBLIC_ALGOLIA_APP_ID;
-const ALGOLIA_API_KEY = process.env.NEXT_PUBLIC_ALGOLIA_PUBLIC_API_KEY;
-const ALGOLIA_INDEX_NAME = process.env.NEXT_PUBLIC_ALGOLIA_INDEX_NAME;
-
-if (!ALGOLIA_APP_ID) {
-  throw new Error('NEXT_PUBLIC_ALGOLIA_APP_ID environment variable is required');
-}
-if (!ALGOLIA_API_KEY) {
-  throw new Error('NEXT_PUBLIC_ALGOLIA_PUBLIC_API_KEY environment variable is required');
-}
-if (!ALGOLIA_INDEX_NAME) {
-  throw new Error('NEXT_PUBLIC_ALGOLIA_INDEX_NAME environment variable is required');
-}
-
-const searchClient = algoliasearch(ALGOLIA_APP_ID, ALGOLIA_API_KEY);
+const searchClient = algoliasearch(
+  process.env.NEXT_PUBLIC_ALGOLIA_APP_ID || '',
+  process.env.NEXT_PUBLIC_ALGOLIA_PUBLIC_API_KEY || '',
+);
 
 /**
  * Algolia search for mobile menu.
@@ -27,10 +15,23 @@ const searchClient = algoliasearch(ALGOLIA_APP_ID, ALGOLIA_API_KEY);
 const MobileSearch = () => {
   const [search, setSearch] = useState<string | null>(null);
   const [hasFocus, sethasFocus] = useState<boolean>(false);
+
+  if (process.env.NODE_ENV === 'development') {
+    if (!process.env.NEXT_PUBLIC_ALGOLIA_APP_ID) {
+      console.warn('MobileSearch: NEXT_PUBLIC_ALGOLIA_APP_ID is not configured');
+    }
+    if (!process.env.NEXT_PUBLIC_ALGOLIA_PUBLIC_API_KEY) {
+      console.warn('MobileSearch: NEXT_PUBLIC_ALGOLIA_PUBLIC_API_KEY is not configured');
+    }
+    if (!process.env.NEXT_PUBLIC_ALGOLIA_INDEX_NAME) {
+      console.warn('MobileSearch: NEXT_PUBLIC_ALGOLIA_INDEX_NAME is not configured');
+    }
+  }
+
   return (
     <div className="inline mt-4 md:hidden">
       <InstantSearch
-        indexName={ALGOLIA_INDEX_NAME}
+        indexName={process.env.NEXT_PUBLIC_ALGOLIA_INDEX_NAME || ''}
         searchClient={searchClient}
       >
         <SearchBox

--- a/src/components/AlgoliaSearch/MobileSearch.component.tsx
+++ b/src/components/AlgoliaSearch/MobileSearch.component.tsx
@@ -4,10 +4,22 @@ import { useState } from 'react';
 
 import SearchResults from './SearchResults.component';
 
-const searchClient = algoliasearch(
-  process.env.NEXT_PUBLIC_ALGOLIA_APP_ID!,
-  process.env.NEXT_PUBLIC_ALGOLIA_PUBLIC_API_KEY!,
-);
+// Validate required environment variables
+const ALGOLIA_APP_ID = process.env.NEXT_PUBLIC_ALGOLIA_APP_ID;
+const ALGOLIA_API_KEY = process.env.NEXT_PUBLIC_ALGOLIA_PUBLIC_API_KEY;
+const ALGOLIA_INDEX_NAME = process.env.NEXT_PUBLIC_ALGOLIA_INDEX_NAME;
+
+if (!ALGOLIA_APP_ID) {
+  throw new Error('NEXT_PUBLIC_ALGOLIA_APP_ID environment variable is required');
+}
+if (!ALGOLIA_API_KEY) {
+  throw new Error('NEXT_PUBLIC_ALGOLIA_PUBLIC_API_KEY environment variable is required');
+}
+if (!ALGOLIA_INDEX_NAME) {
+  throw new Error('NEXT_PUBLIC_ALGOLIA_INDEX_NAME environment variable is required');
+}
+
+const searchClient = algoliasearch(ALGOLIA_APP_ID, ALGOLIA_API_KEY);
 
 /**
  * Algolia search for mobile menu.
@@ -18,7 +30,7 @@ const MobileSearch = () => {
   return (
     <div className="inline mt-4 md:hidden">
       <InstantSearch
-        indexName={process.env.NEXT_PUBLIC_ALGOLIA_INDEX_NAME!}
+        indexName={ALGOLIA_INDEX_NAME}
         searchClient={searchClient}
       >
         <SearchBox

--- a/src/components/AlgoliaSearch/MobileSearch.component.tsx
+++ b/src/components/AlgoliaSearch/MobileSearch.component.tsx
@@ -2,7 +2,7 @@ import { InstantSearch, SearchBox, Hits } from 'react-instantsearch-dom';
 import { useState } from 'react';
 
 import SearchResults from './SearchResults.component';
-import { searchClient, indexName } from '@/utils/algolia/config';
+import { getSearchClient, indexName, isAlgoliaConfigured } from '@/utils/algolia/config';
 
 /**
  * Algolia search for mobile menu.
@@ -10,6 +10,17 @@ import { searchClient, indexName } from '@/utils/algolia/config';
 const MobileSearch = () => {
   const [search, setSearch] = useState<string | null>(null);
   const [hasFocus, sethasFocus] = useState<boolean>(false);
+
+  // Don't render if Algolia is not configured
+  if (!isAlgoliaConfigured) {
+    return null;
+  }
+
+  const searchClient = getSearchClient();
+
+  if (!searchClient) {
+    return null;
+  }
 
   return (
     <div className="inline mt-4 md:hidden">

--- a/src/utils/algolia/config.ts
+++ b/src/utils/algolia/config.ts
@@ -1,0 +1,25 @@
+import { algoliasearch } from 'algoliasearch';
+
+// Environment variables
+const ALGOLIA_APP_ID = process.env.NEXT_PUBLIC_ALGOLIA_APP_ID || '';
+const ALGOLIA_API_KEY = process.env.NEXT_PUBLIC_ALGOLIA_PUBLIC_API_KEY || '';
+const ALGOLIA_INDEX_NAME = process.env.NEXT_PUBLIC_ALGOLIA_INDEX_NAME || '';
+
+// Warn in development if Algolia is not configured
+if (process.env.NODE_ENV === 'development') {
+  if (!process.env.NEXT_PUBLIC_ALGOLIA_APP_ID) {
+    console.warn('Algolia: NEXT_PUBLIC_ALGOLIA_APP_ID is not configured');
+  }
+  if (!process.env.NEXT_PUBLIC_ALGOLIA_PUBLIC_API_KEY) {
+    console.warn('Algolia: NEXT_PUBLIC_ALGOLIA_PUBLIC_API_KEY is not configured');
+  }
+  if (!process.env.NEXT_PUBLIC_ALGOLIA_INDEX_NAME) {
+    console.warn('Algolia: NEXT_PUBLIC_ALGOLIA_INDEX_NAME is not configured');
+  }
+}
+
+// Create Algolia search client
+export const searchClient = algoliasearch(ALGOLIA_APP_ID, ALGOLIA_API_KEY);
+
+// Export index name
+export const indexName = ALGOLIA_INDEX_NAME;

--- a/src/utils/algolia/config.ts
+++ b/src/utils/algolia/config.ts
@@ -1,25 +1,38 @@
-import { algoliasearch } from 'algoliasearch';
+import { algoliasearch, SearchClient } from 'algoliasearch';
 
 // Environment variables
-const ALGOLIA_APP_ID = process.env.NEXT_PUBLIC_ALGOLIA_APP_ID || '';
-const ALGOLIA_API_KEY = process.env.NEXT_PUBLIC_ALGOLIA_PUBLIC_API_KEY || '';
-const ALGOLIA_INDEX_NAME = process.env.NEXT_PUBLIC_ALGOLIA_INDEX_NAME || '';
+const ALGOLIA_APP_ID = process.env.NEXT_PUBLIC_ALGOLIA_APP_ID;
+const ALGOLIA_API_KEY = process.env.NEXT_PUBLIC_ALGOLIA_PUBLIC_API_KEY;
+const ALGOLIA_INDEX_NAME = process.env.NEXT_PUBLIC_ALGOLIA_INDEX_NAME;
+
+// Check if Algolia is properly configured
+const isConfigured = Boolean(ALGOLIA_APP_ID && ALGOLIA_API_KEY && ALGOLIA_INDEX_NAME);
 
 // Warn in development if Algolia is not configured
-if (process.env.NODE_ENV === 'development') {
-  if (!process.env.NEXT_PUBLIC_ALGOLIA_APP_ID) {
-    console.warn('Algolia: NEXT_PUBLIC_ALGOLIA_APP_ID is not configured');
-  }
-  if (!process.env.NEXT_PUBLIC_ALGOLIA_PUBLIC_API_KEY) {
-    console.warn('Algolia: NEXT_PUBLIC_ALGOLIA_PUBLIC_API_KEY is not configured');
-  }
-  if (!process.env.NEXT_PUBLIC_ALGOLIA_INDEX_NAME) {
-    console.warn('Algolia: NEXT_PUBLIC_ALGOLIA_INDEX_NAME is not configured');
-  }
+if (process.env.NODE_ENV === 'development' && !isConfigured) {
+  console.warn('Algolia: Configuration incomplete. Search functionality will be disabled.');
+  if (!ALGOLIA_APP_ID) console.warn('  - NEXT_PUBLIC_ALGOLIA_APP_ID is missing');
+  if (!ALGOLIA_API_KEY) console.warn('  - NEXT_PUBLIC_ALGOLIA_PUBLIC_API_KEY is missing');
+  if (!ALGOLIA_INDEX_NAME) console.warn('  - NEXT_PUBLIC_ALGOLIA_INDEX_NAME is missing');
 }
 
-// Create Algolia search client
-export const searchClient = algoliasearch(ALGOLIA_APP_ID, ALGOLIA_API_KEY);
+// Lazy initialization of search client
+let _searchClient: SearchClient | null = null;
+
+export const getSearchClient = (): SearchClient | null => {
+  if (!isConfigured) {
+    return null;
+  }
+  
+  if (!_searchClient) {
+    _searchClient = algoliasearch(ALGOLIA_APP_ID!, ALGOLIA_API_KEY!);
+  }
+  
+  return _searchClient;
+};
 
 // Export index name
-export const indexName = ALGOLIA_INDEX_NAME;
+export const indexName = ALGOLIA_INDEX_NAME || '';
+
+// Export configuration status
+export const isAlgoliaConfigured = isConfigured;


### PR DESCRIPTION
Replace fallback placeholder defaults with TypeScript non-null assertions in MobileSearch.component.tsx. Removed 'changethis'/'changeme' fallbacks and now require NEXT_PUBLIC_ALGOLIA_APP_ID, NEXT_PUBLIC_ALGOLIA_PUBLIC_API_KEY, and NEXT_PUBLIC_ALGOLIA_INDEX_NAME to be present so missing config surfaces at build/runtime.