### PR TITLE
Update Playwright CI workflow

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -23,28 +23,37 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --ignore-scripts
       - name: Install Playwright Browsers
-        env:
-          npm_config_ignore_scripts: true
-        run: pnpm exec playwright install --with-deps chromium firefox # NOSONAR - playwright install downloads binaries, not npm packages
+        run: pnpm exec playwright install --with-deps
       - name: Build the project
+        run: pnpm run build
         env:
           NEXT_PUBLIC_GRAPHQL_URL: ${{ secrets.NEXT_PUBLIC_GRAPHQL_URL }}
-          NEXT_PUBLIC_ALGOLIA_INDEX_NAME: ${{ secrets.NEXT_PUBLIC_ALGOLIA_INDEX_NAME }}
-          NEXT_PUBLIC_PLACEHOLDER_SMALL_IMAGE_URL: ${{ secrets.NEXT_PUBLIC_PLACEHOLDER_SMALL_IMAGE_URL }}
-          NEXT_PUBLIC_PLACEHOLDER_LARGE_IMAGE_URL: ${{ secrets.NEXT_PUBLIC_PLACEHOLDER_LARGE_IMAGE_URL }}
-          NEXT_PUBLIC_ALGOLIA_APP_ID: ${{ secrets.NEXT_PUBLIC_ALGOLIA_APP_ID }}
-          NEXT_PUBLIC_ALGOLIA_PUBLIC_API_KEY: ${{ secrets.NEXT_PUBLIC_ALGOLIA_PUBLIC_API_KEY }}
-        run: pnpm build
       - name: Start the application
-        run: pnpm start &
+        run: pnpm run start &
+        env:
+          NEXT_PUBLIC_GRAPHQL_URL: ${{ secrets.NEXT_PUBLIC_GRAPHQL_URL }}
       - name: Wait for the application to be ready
         run: |
-          npx --ignore-scripts wait-on@8.0.1 http://localhost:3000
+          echo "Waiting for the application to be ready..."
+          timeout 300 bash -c 'while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' localhost:3000)" != "200" ]]; do sleep 5; done' || false
+          echo "Application is ready!"
       - name: Run Playwright tests
         run: pnpm exec playwright test
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        env:
+          CI: true
+          NEXT_PUBLIC_GRAPHQL_URL: ${{ secrets.NEXT_PUBLIC_GRAPHQL_URL }}
+          DEBUG: pw:api
+      - name: Upload test results
         if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: playwright-report
           path: playwright-report/
+          retention-days: 30
+      - name: Upload test traces
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: playwright-traces
+          path: test-results/
           retention-days: 30

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -27,6 +27,13 @@ jobs:
           npm_config_ignore_scripts: true
         run: pnpm exec playwright install --with-deps chromium firefox # NOSONAR - playwright install downloads binaries, not npm packages
       - name: Build the project
+        env:
+          NEXT_PUBLIC_GRAPHQL_URL: ${{ secrets.NEXT_PUBLIC_GRAPHQL_URL }}
+          NEXT_PUBLIC_ALGOLIA_INDEX_NAME: ${{ secrets.NEXT_PUBLIC_ALGOLIA_INDEX_NAME }}
+          NEXT_PUBLIC_PLACEHOLDER_SMALL_IMAGE_URL: ${{ secrets.NEXT_PUBLIC_PLACEHOLDER_SMALL_IMAGE_URL }}
+          NEXT_PUBLIC_PLACEHOLDER_LARGE_IMAGE_URL: ${{ secrets.NEXT_PUBLIC_PLACEHOLDER_LARGE_IMAGE_URL }}
+          NEXT_PUBLIC_ALGOLIA_APP_ID: ${{ secrets.NEXT_PUBLIC_ALGOLIA_APP_ID }}
+          NEXT_PUBLIC_ALGOLIA_PUBLIC_API_KEY: ${{ secrets.NEXT_PUBLIC_ALGOLIA_PUBLIC_API_KEY }}
         run: pnpm build
       - name: Start the application
         run: pnpm start &

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,55 +1,43 @@
 name: Playwright Tests
 on:
   push:
-    branches: [ main, master ]
+    branches: [main, master]
   pull_request:
-    branches: [ main, master ]
+    branches: [main, master]
+
+permissions:
+  contents: read
+
 jobs:
   test:
     timeout-minutes: 60
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
-    - name: Install pnpm
-      uses: pnpm/action-setup@2e223e0f0d2b8fd9872cbadb8b7428e5f8b5556d
-    - uses: actions/setup-node@v6
-      with:
-        node-version: 24
-        cache: 'pnpm'
-    - name: Install dependencies
-      run: pnpm install --frozen-lockfile --ignore-scripts
-    - name: Install Playwright Browsers
-      run: pnpm exec playwright install --with-deps
-    - name: Build the project
-      run: pnpm run build
-      env:
-        NEXT_PUBLIC_GRAPHQL_URL: ${{ secrets.NEXT_PUBLIC_GRAPHQL_URL }}
-    - name: Start the application
-      run: pnpm run start &
-      env:
-        NEXT_PUBLIC_GRAPHQL_URL: ${{ secrets.NEXT_PUBLIC_GRAPHQL_URL }}
-    - name: Wait for the application to be ready
-      run: |
-        echo "Waiting for the application to be ready..."
-        timeout 300 bash -c 'while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' localhost:3000)" != "200" ]]; do sleep 5; done' || false
-        echo "Application is ready!"
-    - name: Run Playwright tests
-      run: pnpm exec playwright test
-      env:
-        CI: true
-        NEXT_PUBLIC_GRAPHQL_URL: ${{ secrets.NEXT_PUBLIC_GRAPHQL_URL }}
-        DEBUG: pw:api
-    - name: Upload test results
-      if: always()
-      uses: actions/upload-artifact@v7
-      with:
-        name: playwright-report
-        path: playwright-report/
-        retention-days: 30
-    - name: Upload test traces
-      if: failure()
-      uses: actions/upload-artifact@v7
-      with:
-        name: playwright-traces
-        path: test-results/
-        retention-days: 30
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: pnpm/action-setup@2e223e0f0d2b8fd9872cbadb8b7428e5f8b5556d
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: 24
+          cache: "pnpm"
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --ignore-scripts
+      - name: Install Playwright Browsers
+        env:
+          npm_config_ignore_scripts: true
+        run: pnpm exec playwright install --with-deps chromium firefox # NOSONAR - playwright install downloads binaries, not npm packages
+      - name: Build the project
+        run: pnpm build
+      - name: Start the application
+        run: pnpm start &
+      - name: Wait for the application to be ready
+        run: |
+          npx --ignore-scripts wait-on@8.0.1 http://localhost:3000
+      - name: Run Playwright tests
+        run: pnpm exec playwright test
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        if: always()
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 30


### PR DESCRIPTION
Rework Playwright GitHub Actions workflow: normalize branch lists and add permissions: contents: read. Pin actions (checkout, setup-node, upload-artifact) and use pnpm/action-setup. Install dependencies, install Playwright browsers (chromium, firefox) with npm_config_ignore_scripts, build with pnpm build, start the app and wait with npx wait-on, then run Playwright tests and upload the playwright-report artifact. Removed several explicit env vars (NEXT_PUBLIC_GRAPHQL_URL, DEBUG, CI) and the separate traces upload step. Changes improve reproducibility, pin tooling versions, and simplify startup/wait logic.