### PR TITLE
Suppress Sonar warning for Playwright install

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --ignore-scripts
       - name: Install Playwright Browsers
-        run: pnpm exec playwright install --with-deps
+        run: pnpm exec playwright install --with-deps # NOSONAR - playwright install downloads browser binaries, not npm packages
       - name: Build the project
         run: pnpm run build
         env:


### PR DESCRIPTION
Add a NOSONAR inline comment to the Playwright install step in .github/workflows/playwright.yml. The comment clarifies that `pnpm exec playwright install --with-deps` downloads browser binaries (not npm packages), preventing SonarQube from reporting a false positive.