### PR TITLE
Fix broken star history chart

### DIFF
--- a/DOCS/repository_context.txt
+++ b/DOCS/repository_context.txt
@@ -6848,7 +6848,7 @@ export default SingleProduct;
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=w3bdesign/nextjs-woocommerce&type=Date)](https://star-history.com/#w3bdesign/nextjs-woocommerce&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=w3bdesign/nextjs-woocommerce&type=Date)](https://star-history.dera.page/#w3bdesign/nextjs-woocommerce&Date)
 
 # Next.js Ecommerce site with WooCommerce backend
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=w3bdesign/nextjs-woocommerce&type=Date)](https://star-history.com/#w3bdesign/nextjs-woocommerce&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=w3bdesign/nextjs-woocommerce&type=Date)](https://star-history.dera.page/#w3bdesign/nextjs-woocommerce&Date)
 
 # Next.js Ecommerce site with WooCommerce backend
 


### PR DESCRIPTION
The star history chart on this repository was broken and no longer rendering, since it relied on a data source that has been restricted. This change moves the chart to a provider that works without an API token so the chart displays correctly again. No settings were changed, so existing chart behavior is preserved.