### PR TITLE
Make Algolia search input full width

### DIFF
--- a/src/components/AlgoliaSearch/AlgoliaSearchBox.component.tsx
+++ b/src/components/AlgoliaSearch/AlgoliaSearchBox.component.tsx
@@ -30,7 +30,7 @@ const CustomSearchBox = () => {
         classNames={{
           root: '',
           form: '',
-          input: `px-4 py-2 text-base bg-surface border outline-none rounded-md transition-colors duration-200 ${
+          input: `w-full px-4 py-2 text-base bg-surface border outline-none rounded-md transition-colors duration-200 ${
             hasFocus ? 'border-primary' : 'border-border'
           }`,
         }}

--- a/src/components/AlgoliaSearch/AlgoliaSearchBox.component.tsx
+++ b/src/components/AlgoliaSearch/AlgoliaSearchBox.component.tsx
@@ -52,7 +52,7 @@ const CustomSearchBox = () => {
 const AlgoliaSearchBox = () => {
   return (
     <div className="hidden mb-0.5 md:inline-block xl:inline-block">
-      <div className="relative w-72">
+      <div className="relative w-72 md:w-80 lg:w-96 xl:w-[28rem]">
         <InstantSearch
           indexName={process.env.NEXT_PUBLIC_ALGOLIA_INDEX_NAME ?? 'changeme'}
           searchClient={searchClient}

--- a/src/components/AlgoliaSearch/AlgoliaSearchBox.component.tsx
+++ b/src/components/AlgoliaSearch/AlgoliaSearchBox.component.tsx
@@ -1,5 +1,10 @@
 import { liteClient as algoliasearch } from 'algoliasearch/lite';
-import { InstantSearch, SearchBox, Hits, useSearchBox } from 'react-instantsearch';
+import {
+  InstantSearch,
+  SearchBox,
+  Hits,
+  useSearchBox,
+} from 'react-instantsearch';
 import { useState } from 'react';
 
 import SearchResults from './SearchResults.component';
@@ -52,7 +57,7 @@ const CustomSearchBox = () => {
 const AlgoliaSearchBox = () => {
   return (
     <div className="hidden mb-0.5 md:inline-block xl:inline-block">
-      <div className="relative w-72 md:w-80 lg:w-96 xl:w-[28rem]">
+      <div className="relative w-72 lg:w-80 xl:w-96">
         <InstantSearch
           indexName={process.env.NEXT_PUBLIC_ALGOLIA_INDEX_NAME ?? 'changeme'}
           searchClient={searchClient}


### PR DESCRIPTION
Add `w-full` to the input class in CustomSearchBox so the Algolia search field stretches to the container width. Change made in src/components/AlgoliaSearch/AlgoliaSearchBox.component.tsx to improve layout consistency.