### PR TITLE
Improve Algolia search input styling

### DIFF
--- a/src/components/AlgoliaSearch/AlgoliaSearchBox.component.tsx
+++ b/src/components/AlgoliaSearch/AlgoliaSearchBox.component.tsx
@@ -52,7 +52,7 @@ const CustomSearchBox = () => {
 const AlgoliaSearchBox = () => {
   return (
     <div className="hidden mb-0.5 md:inline-block xl:inline-block">
-      <div className="relative w-72">
+      <div className="relative w-80">
         <InstantSearch
           indexName={process.env.NEXT_PUBLIC_ALGOLIA_INDEX_NAME ?? 'changeme'}
           searchClient={searchClient}

--- a/src/components/AlgoliaSearch/AlgoliaSearchBox.component.tsx
+++ b/src/components/AlgoliaSearch/AlgoliaSearchBox.component.tsx
@@ -20,6 +20,25 @@ const CustomSearchBox = () => {
 
   return (
     <>
+      {/* Search icon inside the input, left-aligned like larger e-commerce search bars */}
+      <span className="pointer-events-none absolute left-4 top-1/2 z-10 -translate-y-1/2 text-text-muted">
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="20"
+          height="20"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          aria-hidden="true"
+          focusable="false"
+        >
+          <circle cx="11" cy="11" r="7" />
+          <line x1="21" y1="21" x2="16.65" y2="16.65" />
+        </svg>
+      </span>
       <SearchBox
         aria-label="Søk her"
         placeholder="Søk etter produkter"
@@ -30,8 +49,8 @@ const CustomSearchBox = () => {
         classNames={{
           root: '',
           form: '',
-          input: `px-4 py-2 text-base bg-surface border outline-none rounded-md transition-colors duration-200 ${
-            hasFocus ? 'border-primary' : 'border-border'
+          input: `w-full pl-11 pr-4 py-2.5 text-base bg-surface border shadow-sm outline-none rounded-md transition-colors duration-200 ${
+            hasFocus ? 'border-primary' : 'border-border hover:border-primary/60'
           }`,
         }}
         onFocus={() => setHasFocus(true)}
@@ -51,8 +70,8 @@ const CustomSearchBox = () => {
  */
 const AlgoliaSearchBox = () => {
   return (
-    <div className="hidden mb-0.5 md:inline-block xl:inline-block">
-      <div className="relative w-80">
+    <div className="hidden mb-0.5 md:block md:flex-1 md:max-w-xl md:mx-6">
+      <div className="relative w-full">
         <InstantSearch
           indexName={process.env.NEXT_PUBLIC_ALGOLIA_INDEX_NAME ?? 'changeme'}
           searchClient={searchClient}

--- a/src/components/AlgoliaSearch/AlgoliaSearchBox.component.tsx
+++ b/src/components/AlgoliaSearch/AlgoliaSearchBox.component.tsx
@@ -30,8 +30,8 @@ const CustomSearchBox = () => {
         classNames={{
           root: '',
           form: '',
-          input: `w-full px-4 py-2 text-base bg-surface border shadow-sm outline-none rounded-md transition-colors duration-200 ${
-            hasFocus ? 'border-primary' : 'border-border hover:border-primary/60'
+          input: `px-4 py-2 text-base bg-surface border outline-none rounded-md transition-colors duration-200 ${
+            hasFocus ? 'border-primary' : 'border-border'
           }`,
         }}
         onFocus={() => setHasFocus(true)}

--- a/src/components/AlgoliaSearch/AlgoliaSearchBox.component.tsx
+++ b/src/components/AlgoliaSearch/AlgoliaSearchBox.component.tsx
@@ -30,8 +30,8 @@ const CustomSearchBox = () => {
         classNames={{
           root: '',
           form: '',
-          input: `px-4 py-2 text-base bg-surface border outline-none rounded-md transition-colors duration-200 ${
-            hasFocus ? 'border-primary' : 'border-border'
+          input: `w-full px-4 py-2 text-base bg-surface border shadow-sm outline-none rounded-md transition-colors duration-200 ${
+            hasFocus ? 'border-primary' : 'border-border hover:border-primary/60'
           }`,
         }}
         onFocus={() => setHasFocus(true)}

--- a/src/components/Header/Navbar.component.tsx
+++ b/src/components/Header/Navbar.component.tsx
@@ -48,8 +48,8 @@ const Navbar = () => {
                 NETTBUTIKK
               </span>
             </Link>
+            <AlgoliaSearchBox />
             <div className="flex items-center gap-3">
-              <AlgoliaSearchBox />
               <Cart />
             </div>
           </div>


### PR DESCRIPTION
Updated the Algolia search box input to use the full available width and added a subtle hover border treatment. The focus state remains emphasized with the primary border, while the default state now includes a soft shadow for better visual polish and usability.