### PR TITLE
Make Algolia search box full-width

### DIFF
--- a/src/components/AlgoliaSearch/AlgoliaSearchBox.component.tsx
+++ b/src/components/AlgoliaSearch/AlgoliaSearchBox.component.tsx
@@ -28,9 +28,9 @@ const CustomSearchBox = () => {
           resetButtonTitle: 'Slett søketekst',
         }}
         classNames={{
-          root: 'w-full',
-          form: 'relative w-full',
-          input: `w-full px-4 py-2 text-base bg-surface border outline-none rounded-md transition-colors duration-200 ${
+          root: '',
+          form: 'relative',
+          input: `px-4 py-2 text-base bg-surface border outline-none rounded-md transition-colors duration-200 ${
             hasFocus ? 'border-primary' : 'border-border'
           }`,
         }}

--- a/src/components/AlgoliaSearch/AlgoliaSearchBox.component.tsx
+++ b/src/components/AlgoliaSearch/AlgoliaSearchBox.component.tsx
@@ -28,9 +28,9 @@ const CustomSearchBox = () => {
           resetButtonTitle: 'Slett søketekst',
         }}
         classNames={{
-          root: '',
-          form: '',
-          input: `px-4 py-2 text-base bg-surface border outline-none rounded-md transition-colors duration-200 ${
+          root: 'w-full',
+          form: 'relative w-full',
+          input: `w-full px-4 py-2 text-base bg-surface border outline-none rounded-md transition-colors duration-200 ${
             hasFocus ? 'border-primary' : 'border-border'
           }`,
         }}

--- a/src/components/AlgoliaSearch/AlgoliaSearchBox.component.tsx
+++ b/src/components/AlgoliaSearch/AlgoliaSearchBox.component.tsx
@@ -52,7 +52,7 @@ const CustomSearchBox = () => {
 const AlgoliaSearchBox = () => {
   return (
     <div className="hidden md:flex md:items-center">
-      <div className="relative w-72">
+      <div className="relative">
         <InstantSearch
           indexName={process.env.NEXT_PUBLIC_ALGOLIA_INDEX_NAME ?? 'changeme'}
           searchClient={searchClient}

--- a/src/components/AlgoliaSearch/AlgoliaSearchBox.component.tsx
+++ b/src/components/AlgoliaSearch/AlgoliaSearchBox.component.tsx
@@ -51,7 +51,7 @@ const CustomSearchBox = () => {
  */
 const AlgoliaSearchBox = () => {
   return (
-    <div className="hidden mb-0.5 md:inline-block xl:inline-block">
+    <div className="hidden md:flex md:items-center">
       <div className="relative w-72">
         <InstantSearch
           indexName={process.env.NEXT_PUBLIC_ALGOLIA_INDEX_NAME ?? 'changeme'}

--- a/src/components/Header/Cart.component.tsx
+++ b/src/components/Header/Cart.component.tsx
@@ -18,7 +18,7 @@ const Cart = ({ stickyNav }: ICartProps) => {
     <>
       <Link href="/handlekurv">
         <span
-          className="pl-4 mt-2 no-underline inline-flex items-center"
+          className="pl-4 no-underline inline-flex items-center"
           aria-label="Handlekurv"
         >
           <svg


### PR DESCRIPTION
Add w-full to the root and input and set form to 'relative w-full' so the Algolia search box spans its container and supports absolute-positioned elements. This fixes layout/alignment issues for the search input.