### PR TITLE
Adjust cart badge alignment

### DIFF
--- a/src/components/Header/Cart.component.tsx
+++ b/src/components/Header/Cart.component.tsx
@@ -38,7 +38,7 @@ const Cart = ({ stickyNav }: ICartProps) => {
 
         {productCount > 0 && (
           <span
-            className={`absolute top-1 right-2 w-6 h-6 flex items-center justify-center text-xs text-center rounded-full
+            className={`absolute top-1 -right-1 w-6 h-6 flex items-center justify-center text-xs text-center rounded-full
             ${stickyNav ? 'text-primary-dark bg-white' : 'text-white bg-primary'}`}
           >
             {productCount}


### PR DESCRIPTION
Update the cart count badge position in the header so it sits correctly relative to the cart icon in both sticky and non-sticky navigation states.