### PR TITLE
Adjust cart badge position

### DIFF
--- a/src/components/Header/Cart.component.tsx
+++ b/src/components/Header/Cart.component.tsx
@@ -38,7 +38,7 @@ const Cart = ({ stickyNav }: ICartProps) => {
 
         {productCount > 0 && (
           <span
-            className={`absolute top-1 -right-1 w-6 h-6 flex items-center justify-center text-xs text-center rounded-full
+            className={`absolute -top-1 -right-3 w-6 h-6 flex items-center justify-center text-xs text-center rounded-full
             ${stickyNav ? 'text-primary-dark bg-white' : 'text-white bg-primary'}`}
           >
             {productCount}


### PR DESCRIPTION
This change tweaks the cart counter badge alignment in the header so it sits closer to the cart icon while preserving the existing sticky navigation color behavior. The update is limited to positioning, without altering the badge's logic or styling states.