### PR TITLE
Adjust AlgoliaSearchBox styling and layout

### DIFF
--- a/src/components/AlgoliaSearch/AlgoliaSearchBox.component.tsx
+++ b/src/components/AlgoliaSearch/AlgoliaSearchBox.component.tsx
@@ -28,11 +28,13 @@ const CustomSearchBox = () => {
           resetButtonTitle: 'Slett søketekst',
         }}
         classNames={{
-          root: '',
-          form: '',
-          input: `px-4 py-2 text-base bg-surface border outline-none rounded-md transition-colors duration-200 ${
+          root: 'w-full',
+          form: 'relative w-full',
+          input: `w-full px-4 py-2 pr-10 text-base bg-surface border outline-none rounded-md transition-colors duration-200 ${
             hasFocus ? 'border-primary' : 'border-border'
           }`,
+          reset:
+            'absolute right-3 top-1/2 -translate-y-1/2 flex items-center justify-center',
         }}
         onFocus={() => setHasFocus(true)}
         onBlur={() => setHasFocus(false)}

--- a/src/components/AlgoliaSearch/AlgoliaSearchBox.component.tsx
+++ b/src/components/AlgoliaSearch/AlgoliaSearchBox.component.tsx
@@ -28,13 +28,11 @@ const CustomSearchBox = () => {
           resetButtonTitle: 'Slett søketekst',
         }}
         classNames={{
-          root: 'w-full',
-          form: 'relative w-full',
-          input: `w-full px-4 py-2 pr-10 text-base bg-surface border outline-none rounded-md transition-colors duration-200 ${
+          root: '',
+          form: '',
+          input: `px-4 py-2 text-base bg-surface border outline-none rounded-md transition-colors duration-200 ${
             hasFocus ? 'border-primary' : 'border-border'
           }`,
-          reset:
-            'absolute right-3 top-1/2 -translate-y-1/2 flex items-center justify-center',
         }}
         onFocus={() => setHasFocus(true)}
         onBlur={() => setHasFocus(false)}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -105,9 +105,14 @@ body {
   right: 0.75rem;
   margin-left: 0;
   transform: translateY(-50%);
-  display: flex;
   align-items: center;
   justify-content: center;
+}
+
+/* Keep the reset (X) button hidden while the input is empty */
+
+.ais-SearchBox-reset[hidden] {
+  display: none;
 }
 
 .ais-Hits {

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -76,12 +76,6 @@ body {
   margin-top: -20px;
 }
 
-/* Fix Algolia search input background to match design system */
-
-.ais-SearchBox-input {
-  background-color: var(--color-surface);
-}
-
 /* Align input, results dropdown and reset (X) button to the same width */
 
 .ais-SearchBox-form {
@@ -94,6 +88,7 @@ body {
   width: 100%;
   padding-right: 2.5rem;
   box-sizing: border-box;
+  background-color: var(--color-surface);
 }
 
 .ais-SearchBox-submit {

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -82,15 +82,22 @@ body {
   background-color: var(--color-surface);
 }
 
-/* Fix Algolia mobile searchbox design issues */
+/* Align input, results dropdown and reset (X) button to the same width */
 
-#mobilesearchdiv {
-  position: absolute;
-  height: 200px;
+.ais-SearchBox-form {
+  position: relative;
+  width: 100%;
+  display: block;
+}
+
+.ais-SearchBox-input {
+  width: 100%;
+  padding-right: 2.5rem;
+  box-sizing: border-box;
 }
 
 .ais-SearchBox-submit {
-  width: 48px;
+  display: none;
 }
 
 .ais-SearchBox-submitIcon {
@@ -98,11 +105,29 @@ body {
 }
 
 .ais-SearchBox-reset {
-  margin-left: 10px;
+  position: absolute;
+  top: 50%;
+  right: 0.75rem;
+  margin-left: 0;
+  transform: translateY(-50%);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.ais-Hits {
+  width: 100%;
 }
 
 /* Fix Chrome padding issue */
 
 .ais-SearchBox-input[type='search']::-webkit-search-cancel-button {
   display: none;
+}
+
+/* Fix Algolia mobile searchbox design issues */
+
+#mobilesearchdiv {
+  position: absolute;
+  height: 200px;
 }


### PR DESCRIPTION
Add root and form classNames for full-width layout, make input full width with right padding for the reset icon, and position the reset button absolutely. Keeps existing focus border behavior and improves overall alignment and spacing.