### PR TITLE
Add responsive spacing to product grid

### DIFF
--- a/src/components/Layout/Layout.component.tsx
+++ b/src/components/Layout/Layout.component.tsx
@@ -25,7 +25,7 @@ const Layout = ({ children, title }: ILayoutProps) => {
     <div className="flex flex-col min-h-screen w-full mx-auto bg-surface">
       <Header title={title} />
       {title === 'Hjem' ? (
-        <main className="flex-1 px-4 md:px-0">{children}</main>
+        <main className="flex-1">{children}</main>
       ) : (
         <div className="container mx-auto px-6 flex-1">
           <PageTitle title={title} />

--- a/src/components/Product/DisplayProducts.component.tsx
+++ b/src/components/Product/DisplayProducts.component.tsx
@@ -19,7 +19,7 @@ interface IDisplayProductsProps {
  */
 
 const DisplayProducts = ({ products }: IDisplayProductsProps) => (
-  <section className="container mx-auto bg-surface py-12">
+  <section className="container mx-auto bg-surface py-12 px-4 md:px-6 xl:px-8">
     <div
       id="product-container"
       className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-8"


### PR DESCRIPTION
Adjust the product listing section to include horizontal padding across breakpoints so the grid has better spacing and a cleaner responsive layout.