### PR TITLE
Centralize cart state and mutations

### DIFF
--- a/DOCS/architecture-review-2026-08-24.html
+++ b/DOCS/architecture-review-2026-08-24.html
@@ -37,10 +37,10 @@
         <!-- ========== CANDIDATE 1 ========== -->
         <article id="c1" class="rounded-xl border border-stone-200 bg-white p-6 shadow-sm space-y-4">
           <div class="flex items-start justify-between gap-4">
-            <h2 class="font-serif text-xl font-semibold">1 · Deepen the Cart into one module</h2>
+            <h2 class="font-serif text-xl font-semibold line-through decoration-2 text-slate-400">1 · Deepen the Cart into one module</h2>
             <div class="flex gap-2 shrink-0">
               <span class="rounded-full bg-emerald-100 text-emerald-800 px-3 py-1 text-xs font-semibold">Strong</span>
-              <span class="rounded-full bg-slate-100 text-slate-600 px-3 py-1 text-xs">in-process</span>
+              <span class="rounded-full bg-emerald-600 text-white px-3 py-1 text-xs font-semibold">✓ done · 2026-08-24</span>
             </div>
           </div>
           <div class="font-mono text-sm text-slate-600 leading-relaxed">
@@ -110,6 +110,13 @@ flowchart TB
             <li>settle-hack fixed once, everywhere</li>
             <li>delete 4 copies of the ritual</li>
           </ul>
+          <div class="rounded-lg border border-emerald-200 bg-emerald-50 p-4 text-sm space-y-1">
+            <p class="module-label text-emerald-700">Delivered · 2026-08-24</p>
+            <p>All four call sites now consume <code class="font-mono">useCart()</code> (<code class="font-mono">src/hooks/useCart.ts</code>); <code class="font-mono">getFormattedCart</code>/<code class="font-mono">getUpdatedItems</code> moved to <code class="font-mono">src/hooks/cart/cartUtils.ts</code> as private helpers.</p>
+            <p><code class="font-mono">cartStore</code> shrank to <code class="font-mono">cart · replace() · clear()</code>; the grab-bag cart functions left <code class="font-mono">functions.tsx</code> (candidates 3 &amp; 4 folded in).</p>
+            <p><strong>Settle-hack eliminated, not merely centralized:</strong> <code class="font-mono">ADD_TO_CART</code>/<code class="font-mono">UPDATE_CART</code> now return the full cart via a shared <code class="font-mono">CartFields</code> fragment, so the store syncs from the mutation's own reply — the <code class="font-mono">setTimeout(refetch)</code> race is gone.</p>
+            <p>One source of truth: <code class="font-mono">setQuantity</code> derives its input from the same store cart the UI renders from.</p>
+          </div>
         </article>
 
         <!-- ========== CANDIDATE 2 ========== -->

--- a/src/components/Cart/CartContents.component.tsx
+++ b/src/components/Cart/CartContents.component.tsx
@@ -6,6 +6,8 @@ import { useCart } from '@/hooks/useCart';
 import Button from '@/components/UI/Button.component';
 import LoadingSpinner from '../LoadingSpinner/LoadingSpinner.component';
 
+import type { ChangeEvent } from 'react';
+
 import type { CartProduct } from '@/types/cart';
 
 const CartContents = () => {
@@ -17,7 +19,7 @@ const CartContents = () => {
   const hasProducts = products.length > 0;
 
   const handleQuantityInput = (
-    event: React.ChangeEvent<HTMLInputElement>,
+    event: ChangeEvent<HTMLInputElement>,
     cartKey: string,
   ) => {
     if (isUpdating) {

--- a/src/components/Cart/CartContents.component.tsx
+++ b/src/components/Cart/CartContents.component.tsx
@@ -23,7 +23,9 @@ const CartContents = () => {
     if (isUpdating) {
       return;
     }
-    const newQty = event.target.value ? parseInt(event.target.value, 10) : 1;
+    const newQty = event.target.value
+      ? Number.parseInt(event.target.value, 10)
+      : 1;
     setQuantity(cartKey, newQty);
   };
 

--- a/src/components/Cart/CartContents.component.tsx
+++ b/src/components/Cart/CartContents.component.tsx
@@ -1,108 +1,46 @@
-import { useEffect } from 'react';
-import { useMutation, useQuery } from '@apollo/client';
 import Link from 'next/link';
 import Image from 'next/image';
 import { useRouter } from 'next/router';
-import { v4 as uuidv4 } from 'uuid';
 
-import { useCartStore } from '@/stores/cartStore';
+import { useCart } from '@/hooks/useCart';
 import Button from '@/components/UI/Button.component';
 import LoadingSpinner from '../LoadingSpinner/LoadingSpinner.component';
 
-import {
-  getFormattedCart,
-  getUpdatedItems,
-  handleQuantityChange,
-  IProductRootObject,
-} from '@/utils/functions/functions';
-
-import { GET_CART } from '@/utils/gql/GQL_QUERIES';
-import { UPDATE_CART } from '@/utils/gql/GQL_MUTATIONS';
-
-// Pure function moved to module scope to avoid rebuilding on every render
-const getUnitPrice = (subtotal: string, quantity: number) => {
-  const numericSubtotal = Number.parseFloat(subtotal.replace(/[^0-9.-]+/g, ''));
-  return Number.isNaN(numericSubtotal)
-    ? 'N/A'
-    : (numericSubtotal / quantity).toFixed(2);
-};
+import type { CartProduct } from '@/types/cart';
 
 const CartContents = () => {
   const router = useRouter();
-  const { clearWooCommerceSession, syncWithWooCommerce } = useCartStore();
   const isCheckoutPage = router.pathname === '/kasse';
+  const { cart, isLoading, isUpdating, setQuantity, removeItem } = useCart();
 
-  const { data, refetch } = useQuery(GET_CART, {
-    notifyOnNetworkStatusChange: true,
-    onCompleted: () => {
-      const updatedCart = getFormattedCart(data);
-      if (!updatedCart && !data?.cart?.contents?.nodes?.length) {
-        clearWooCommerceSession();
-        return;
-      }
-      if (updatedCart) {
-        syncWithWooCommerce(updatedCart);
-      }
-    },
-  });
+  const products = cart?.products ?? [];
+  const hasProducts = products.length > 0;
 
-  const [updateCart, { loading: updateCartProcessing }] = useMutation(
-    UPDATE_CART,
-    {
-      onCompleted: () => {
-        refetch();
-        // Delayed refetch to ensure WooCommerce backend has settled
-        setTimeout(() => {
-          refetch();
-        }, 3000);
-      },
-    },
-  );
-
-  const handleRemoveProductClick = (
+  const handleQuantityInput = (
+    event: React.ChangeEvent<HTMLInputElement>,
     cartKey: string,
-    products: IProductRootObject[],
   ) => {
-    if (products?.length) {
-      const updatedItems = getUpdatedItems(products, 0, cartKey);
-      updateCart({
-        variables: {
-          input: {
-            clientMutationId: uuidv4(),
-            items: updatedItems,
-          },
-        },
-      });
+    if (isUpdating) {
+      return;
     }
-    refetch();
-    // Delayed refetch to ensure WooCommerce backend has settled
-    setTimeout(() => {
-      refetch();
-    }, 3000);
+    const newQty = event.target.value ? parseInt(event.target.value, 10) : 1;
+    setQuantity(cartKey, newQty);
   };
-
-  useEffect(() => {
-    refetch();
-  }, [refetch]);
-
-  const cartTotal = data?.cart?.total || '0';
 
   return (
     <div className="container mx-auto px-4 py-8">
-      {data?.cart?.contents?.nodes?.length ? (
+      {hasProducts ? (
         <>
           <div className="bg-surface rounded-lg p-6 mb-8 md:w-full">
-            {data.cart.contents.nodes.map((item: IProductRootObject) => (
+            {products.map((item: CartProduct) => (
               <div
-                key={item.key}
+                key={item.cartKey}
                 className="flex items-center border-b border-border py-4"
               >
                 <div className="flex-shrink-0 size-24 relative hidden md:block">
                   <Image
-                    src={
-                      item.product.node.image?.sourceUrl || '/placeholder.png'
-                    }
-                    alt={item.product.node.name}
+                    src={item.image?.sourceUrl || '/placeholder.png'}
+                    alt={item.name}
                     layout="fill"
                     objectFit="cover"
                     className="rounded-md"
@@ -110,44 +48,33 @@ const CartContents = () => {
                 </div>
                 <div className="flex-grow ml-4">
                   <h2 className="text-lg font-semibold text-text">
-                    {item.product.node.name}
+                    {item.name}
                   </h2>
-                  <p className="text-text-muted">
-                    kr {getUnitPrice(item.subtotal, item.quantity)}
-                  </p>
+                  <p className="text-text-muted">kr {item.price.toFixed(2)}</p>
                 </div>
                 <div className="flex items-center">
                   <input
                     type="number"
                     min="1"
-                    value={item.quantity}
-                    onChange={(event) => {
-                      handleQuantityChange(
-                        event,
-                        item.key,
-                        data.cart.contents.nodes,
-                        updateCart,
-                        updateCartProcessing,
-                      );
-                    }}
+                    value={item.qty}
+                    onChange={(event) =>
+                      handleQuantityInput(event, item.cartKey)
+                    }
                     className="w-16 px-2 py-1 text-center border border-border rounded-md mr-2 bg-surface focus:ring-2 focus:ring-primary focus:border-primary"
-                    aria-label={`Antall ${item.product.node.name}`}
+                    aria-label={`Antall ${item.name}`}
                   />
                   <Button
-                    handleButtonClick={() =>
-                      handleRemoveProductClick(
-                        item.key,
-                        data.cart.contents.nodes,
-                      )
-                    }
+                    handleButtonClick={() => removeItem(item.cartKey)}
                     variant="secondary"
-                    buttonDisabled={updateCartProcessing}
+                    buttonDisabled={isUpdating}
                   >
                     Fjern
                   </Button>
                 </div>
                 <div className="ml-4">
-                  <p className="text-lg font-semibold text-text">{item.subtotal}</p>
+                  <p className="text-lg font-semibold text-text">
+                    {item.totalPrice}
+                  </p>
                 </div>
               </div>
             ))}
@@ -155,28 +82,32 @@ const CartContents = () => {
           <div className="bg-surface rounded-lg p-6 md:w-full">
             <div className="flex justify-end mb-4">
               <span className="font-semibold pr-2 text-text">Subtotal:</span>
-              <span className="text-text">{cartTotal}</span>
+              <span className="text-text">{cart?.totalProductsPrice}</span>
             </div>
             {!isCheckoutPage && (
               <div className="flex justify-center mb-4">
                 <Link href="/kasse" passHref>
-                  <Button variant="primary" fullWidth>GÅ TIL KASSE</Button>
+                  <Button variant="primary" fullWidth>
+                    GÅ TIL KASSE
+                  </Button>
                 </Link>
               </div>
             )}
           </div>
         </>
       ) : (
-        <div className="text-center">
-          <h2 className="text-2xl font-semibold mb-4 text-text">
-            Ingen produkter i handlekurven
-          </h2>
-          <Link href="/produkter" passHref>
-            <Button variant="primary">Fortsett å handle</Button>
-          </Link>
-        </div>
+        !isLoading && (
+          <div className="text-center">
+            <h2 className="text-2xl font-semibold mb-4 text-text">
+              Ingen produkter i handlekurven
+            </h2>
+            <Link href="/produkter" passHref>
+              <Button variant="primary">Fortsett å handle</Button>
+            </Link>
+          </div>
+        )
       )}
-      {updateCartProcessing && (
+      {isUpdating && (
         <div className="fixed inset-0 flex items-center justify-center bg-overlay bg-opacity-50">
           <div className="bg-surface p-4 rounded-lg">
             <p className="text-lg mb-2 text-text">Oppdaterer handlekurv…</p>

--- a/src/components/Cart/CartInitializer.component.tsx
+++ b/src/components/Cart/CartInitializer.component.tsx
@@ -1,42 +1,13 @@
-import { useEffect } from 'react';
-import { useQuery } from '@apollo/client';
-
-// State
-import { useCartStore } from '@/stores/cartStore';
-
-// Utils
-import { getFormattedCart } from '@/utils/functions/functions';
-
-// GraphQL
-import { GET_CART } from '@/utils/gql/GQL_QUERIES';
+import { useCart } from '@/hooks/useCart';
 
 /**
- * Non-rendering component responsible for initializing the cart state
- * by fetching data from WooCommerce and syncing it with the Zustand store.
- * This should be rendered once at the application root (_app.tsx).
+ * Non-rendering component that mounts the Cart module once at the application
+ * root (_app.tsx). All fetch/format/sync behaviour lives inside useCart().
  * @function CartInitializer
  * @returns {null} - This component does not render any UI
  */
 const CartInitializer = () => {
-  const { syncWithWooCommerce } = useCartStore();
-
-  const { data, refetch } = useQuery(GET_CART, {
-    notifyOnNetworkStatusChange: true,
-    onCompleted: () => {
-      // On successful fetch, format the data and sync with the store
-      const updatedCart = getFormattedCart(data);
-      if (updatedCart) {
-        syncWithWooCommerce(updatedCart);
-      }
-    },
-    // Consider error handling if needed (e.g., onError callback)
-  });
-
-  useEffect(() => {
-    refetch();
-  }, [refetch]);
-
-  // This component does not render any UI
+  useCart();
   return null;
 };
 

--- a/src/components/Checkout/CheckoutForm.component.tsx
+++ b/src/components/Checkout/CheckoutForm.component.tsx
@@ -1,63 +1,43 @@
-/*eslint complexity: ["error", 20]*/
 // Imports
-import { useState, useEffect } from 'react';
-import { useQuery, useMutation, ApolloError } from '@apollo/client';
+import { useState } from 'react';
+import { useMutation, ApolloError } from '@apollo/client';
 
 // Components
 import Billing from './Billing.component';
 import CartContents from '../Cart/CartContents.component';
 import LoadingSpinner from '../LoadingSpinner/LoadingSpinner.component';
 
+// Cart module
+import { useCart } from '@/hooks/useCart';
+
 // GraphQL
-import { GET_CART } from '@/utils/gql/GQL_QUERIES';
 import { CHECKOUT_MUTATION } from '@/utils/gql/GQL_MUTATIONS';
-import { useCartStore } from '@/stores/cartStore';
 
 // Utils
-import { getFormattedCart, createCheckoutData } from '@/utils/functions/functions';
+import { createCheckoutData } from '@/utils/functions/functions';
 
 // Types
 import type { ICheckoutDataProps } from '@/types/checkout';
 
 const CheckoutForm = () => {
-  const { cart, clearWooCommerceSession, syncWithWooCommerce } = useCartStore();
+  const { cart, isLoading, refetchCart } = useCart();
   const [requestError, setRequestError] = useState<ApolloError | null>(null);
   const [orderCompleted, setorderCompleted] = useState<boolean>(false);
-
-  // Get cart data query
-  const { data, refetch } = useQuery(GET_CART, {
-    notifyOnNetworkStatusChange: true,
-    onCompleted: () => {
-      const updatedCart = getFormattedCart(data);
-      if (!updatedCart && !data?.cart?.contents?.nodes?.length) {
-        clearWooCommerceSession();
-        return;
-      }
-      if (updatedCart) {
-        syncWithWooCommerce(updatedCart);
-      }
-    },
-  });
 
   // Checkout GraphQL mutation
   const [checkout, { loading: checkoutLoading }] = useMutation(
     CHECKOUT_MUTATION,
     {
       onCompleted: () => {
-        clearWooCommerceSession();
         setorderCompleted(true);
-        refetch();
+        refetchCart();
       },
       onError: (error) => {
         setRequestError(error);
-        refetch();
+        refetchCart();
       },
     },
   );
-
-  useEffect(() => {
-    refetch();
-  }, [refetch]);
 
   const handleFormSubmit = (submitData: ICheckoutDataProps) => {
     const checkOutData = createCheckoutData(submitData);
@@ -67,10 +47,6 @@ const CheckoutForm = () => {
         input: checkOutData,
       },
     });
-    // Delayed refetch to ensure WooCommerce backend has settled
-    setTimeout(() => {
-      refetch();
-    }, 2000);
   };
 
   return (
@@ -97,7 +73,7 @@ const CheckoutForm = () => {
         </div>
       ) : (
         <>
-          {!cart && !orderCompleted && (
+          {!cart && !orderCompleted && !isLoading && (
             <h1 className="text-2xl m-12 mt-24 font-semibold text-center text-text">
               Ingen produkter i handlekurven
             </h1>

--- a/src/components/Product/AddToCart.component.tsx
+++ b/src/components/Product/AddToCart.component.tsx
@@ -1,95 +1,38 @@
-// Imports
-import { useState } from 'react';
-import { useQuery, useMutation } from '@apollo/client';
-import { v4 as uuidv4 } from 'uuid';
-
 // Components
 import Button from '@/components/UI/Button.component';
 
-// State
-import { useCartStore } from '@/stores/cartStore';
-
-// Utils
-import { getFormattedCart } from '@/utils/functions/functions';
+// Cart module
+import { useCart } from '@/hooks/useCart';
 
 // Types
-import type {
-  ISingleProduct,
-  ISingleProductProps,
-  IVariationDetail,
-} from '@/types/product';
-
-// GraphQL
-import { GET_CART } from '@/utils/gql/GQL_QUERIES';
-import { ADD_TO_CART } from '@/utils/gql/GQL_MUTATIONS';
-
-// Re-export types for backward compatibility
-export type IProduct = ISingleProduct;
-export type IProductRootObject = ISingleProductProps;
-export type IVariationNodes = IVariationDetail;
+import type { ISingleProductProps } from '@/types/product';
 
 /**
  * Handles the Add to cart functionality.
- * Uses GraphQL for product data
  * @param {ISingleProductProps} product // Product data
  * @param {number} variationId // Variation ID
  * @param {boolean} fullWidth // Whether the button should be full-width
  */
-
 const AddToCart = ({
   product,
   variationId,
   fullWidth = false,
 }: ISingleProductProps) => {
-  const { syncWithWooCommerce, isLoading: isCartLoading } = useCartStore();
-  const [requestError, setRequestError] = useState<boolean>(false);
-
-  const productQueryInput = {
-    clientMutationId: uuidv4(), // Generate a unique id.
-    productId: product?.databaseId,
-    ...(variationId ? { variationId } : {}),
-  };
-
-  // Get cart data query
-  const { data, refetch } = useQuery(GET_CART, {
-    notifyOnNetworkStatusChange: true,
-    onCompleted: () => {
-      const updatedCart = getFormattedCart(data);
-      if (updatedCart) {
-        syncWithWooCommerce(updatedCart);
-      }
-    },
-  });
-
-  // Add to cart mutation
-  const [addToCart, { loading: addToCartLoading }] = useMutation(ADD_TO_CART, {
-    variables: {
-      input: productQueryInput,
-    },
-    refetchQueries: [{ query: GET_CART }],
-    onCompleted: () => {
-      // Delayed refetch to ensure WooCommerce backend has settled
-      setTimeout(() => {
-        refetch();
-      }, 2000);
-    },
-
-    onError: () => {
-      setRequestError(true);
-    },
-  });
+  const { addItem, isLoading, isUpdating } = useCart();
 
   const handleAddToCart = () => {
-    addToCart();
+    if (product?.databaseId) {
+      addItem(product.databaseId, variationId);
+    }
   };
 
   return (
     <Button
-      handleButtonClick={() => handleAddToCart()}
-      buttonDisabled={addToCartLoading || requestError || isCartLoading}
+      handleButtonClick={handleAddToCart}
+      buttonDisabled={isUpdating || isLoading}
       fullWidth={fullWidth}
     >
-      {isCartLoading ? 'Loading...' : 'KJØP'}
+      {isLoading ? 'Loading...' : 'KJØP'}
     </Button>
   );
 };

--- a/src/hooks/cart/cartUtils.ts
+++ b/src/hooks/cart/cartUtils.ts
@@ -6,11 +6,7 @@
  */
 
 import type { CartProduct, Cart } from '@/types/cart';
-import type {
-  ICartItemNode,
-  IUpdateCartItem,
-  IFormattedCartProps,
-} from '@/types/graphql';
+import type { IUpdateCartItem, IFormattedCartProps } from '@/types/graphql';
 
 /**
  * Convert a WooCommerce cart GraphQL response into the client-side Cart shape.
@@ -75,13 +71,17 @@ export const getFormattedCart = (
 /**
  * Build the items array for the UPDATE_CART mutation: keep every existing
  * quantity, overriding only the line item identified by cartKey.
+ *
+ * Derives from the same formatted `CartProduct[]` the UI renders from, so the
+ * mutation input can never disagree with what the user sees (one source of
+ * truth instead of reading a parallel Apollo query result).
  */
 export const getUpdatedItems = (
-  products: ICartItemNode[],
+  products: CartProduct[],
   newQty: number,
   cartKey: string,
 ): IUpdateCartItem[] =>
-  products.map((cartItem) => ({
-    key: cartItem.key,
-    quantity: cartItem.key === cartKey ? newQty : cartItem.quantity,
+  products.map((item) => ({
+    key: item.cartKey,
+    quantity: item.cartKey === cartKey ? newQty : item.qty,
   }));

--- a/src/hooks/cart/cartUtils.ts
+++ b/src/hooks/cart/cartUtils.ts
@@ -1,0 +1,87 @@
+/**
+ * Private helpers for the Cart module (see useCart).
+ * These shape WooCommerce GraphQL responses into the client-side Cart
+ * and build mutation inputs. They are implementation details of useCart()
+ * and should not be imported directly by components.
+ */
+
+import type { CartProduct, Cart } from '@/types/cart';
+import type {
+  ICartItemNode,
+  IUpdateCartItem,
+  IFormattedCartProps,
+} from '@/types/graphql';
+
+/**
+ * Convert a WooCommerce cart GraphQL response into the client-side Cart shape.
+ * Returns undefined when the cart is empty so callers can treat "empty" and
+ * "no data" uniformly.
+ * @param {IFormattedCartProps} data Cart data from the GET_CART query
+ */
+export const getFormattedCart = (
+  data: IFormattedCartProps | undefined,
+): Cart | undefined => {
+  if (!data?.cart?.contents?.nodes?.length) {
+    return undefined;
+  }
+
+  const givenProducts = data.cart.contents.nodes;
+
+  const formattedCart: Cart = {
+    products: [],
+    totalProductsCount: 0,
+    totalProductsPrice: 0,
+  };
+
+  let totalProductsCount = 0;
+
+  givenProducts.forEach((item) => {
+    const givenProduct = item.product.node;
+
+    // Convert price to a float value
+    const convertedCurrency = item.total.replace(/[^0-9.-]+/g, '');
+
+    // Create a new product object for each item to avoid shared reference bug
+    const product: CartProduct = {
+      productId: givenProduct.productId,
+      cartKey: item.key,
+      name: givenProduct.name,
+      qty: item.quantity,
+      price: Number(convertedCurrency) / item.quantity,
+      totalPrice: item.total,
+      image: givenProduct.image?.sourceUrl
+        ? {
+            sourceUrl: givenProduct.image.sourceUrl,
+            srcSet: givenProduct.image.srcSet,
+            title: givenProduct.image.title,
+          }
+        : {
+            sourceUrl: process.env.NEXT_PUBLIC_PLACEHOLDER_SMALL_IMAGE_URL,
+            srcSet: process.env.NEXT_PUBLIC_PLACEHOLDER_SMALL_IMAGE_URL,
+            title: givenProduct.name,
+          },
+    };
+
+    totalProductsCount += item.quantity;
+    formattedCart.products.push(product);
+  });
+
+  formattedCart.totalProductsCount = totalProductsCount;
+  formattedCart.totalProductsPrice = data.cart.total;
+
+  return formattedCart;
+};
+
+/**
+ * Build the items array for the UPDATE_CART mutation: keep every existing
+ * quantity, overriding only the line item identified by cartKey.
+ */
+export const getUpdatedItems = (
+  products: ICartItemNode[],
+  newQty: number,
+  cartKey: string,
+): IUpdateCartItem[] =>
+  products.map((cartItem) => ({
+    key: cartItem.key,
+    quantity: cartItem.key === cartKey ? newQty : cartItem.quantity,
+  }));

--- a/src/hooks/useCart.ts
+++ b/src/hooks/useCart.ts
@@ -1,0 +1,182 @@
+import { useCallback, useEffect, useRef } from 'react';
+import {
+  NetworkStatus,
+  useMutation,
+  useQuery,
+  type ApolloError,
+} from '@apollo/client';
+import { v4 as uuidv4 } from 'uuid';
+
+// State
+import { useCartStore } from '@/stores/cartStore';
+
+// GraphQL
+import { GET_CART } from '@/utils/gql/GQL_QUERIES';
+import { ADD_TO_CART, UPDATE_CART } from '@/utils/gql/GQL_MUTATIONS';
+
+// Private helpers of the Cart module
+import { getFormattedCart, getUpdatedItems } from './cart/cartUtils';
+
+// Types
+import type { Cart } from '@/types/cart';
+import type { ICartItemNode, IFormattedCartProps } from '@/types/graphql';
+
+/**
+ * How long to wait before the reconciling refetch fires. WooCommerce needs a
+ * moment for the session/cart to settle after a mutation; a single source of
+ * truth for this delay replaces the 2s/3s copies scattered across components.
+ */
+const SETTLE_REFETCH_MS = 2000;
+
+export interface UseCartResult {
+  /** Formatted, client-side cart. Null when empty or not yet loaded. */
+  cart: Cart | null;
+  /** True until the first GET_CART for this mount has settled. */
+  isLoading: boolean;
+  /** True while an add/update/remove mutation (or its settle refetch) is in flight. */
+  isUpdating: boolean;
+  /** Set if the cart query failed. */
+  error?: ApolloError;
+  /** Add a product (optionally a variation) to the cart. */
+  addItem: (productId: number, variationId?: number) => void;
+  /** Set the quantity of a single line item by cart key. */
+  setQuantity: (cartKey: string, quantity: number) => void;
+  /** Remove a single line item by cart key. */
+  removeItem: (cartKey: string) => void;
+  /** Force a re-read of the cart from WooCommerce. */
+  refetchCart: () => void;
+}
+
+/**
+ * The Cart module's single public interface.
+ *
+ * Owns the entire fetch → format → sync → settle-refetch ritual that used to be
+ * copy-pasted across CartInitializer, CartContents, AddToCart and CheckoutForm.
+ * Query, mutations, formatting, the settle-refetch hack, store sync and
+ * empty-cart session clearing are all implementation details behind this hook.
+ *
+ * Rendering reads the persisted store `cart` (so the UI never flashes empty on
+ * hydration); decisions that could destroy the session — showing the empty
+ * state, clearing the session — are gated on `!isLoading` so they never act on
+ * an unvalidated cache.
+ */
+export const useCart = (): UseCartResult => {
+  const cart = useCartStore((state) => state.cart);
+  const replace = useCartStore((state) => state.replace);
+  const clear = useCartStore((state) => state.clear);
+
+  // Track pending settle-refetch timers so they can be cleared on unmount.
+  const settleTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const {
+    data,
+    error,
+    refetch,
+    networkStatus,
+  } = useQuery<IFormattedCartProps>(GET_CART, {
+    notifyOnNetworkStatusChange: true,
+    onCompleted: (completed) => {
+      const formatted = getFormattedCart(completed);
+      if (!formatted && !completed?.cart?.contents?.nodes?.length) {
+        // Cart is genuinely empty after a settled fetch — clear the session.
+        clear();
+        return;
+      }
+      if (formatted) {
+        replace(formatted);
+      }
+    },
+  });
+
+  // isLoading is true only until the first fetch settles for this mount.
+  const isLoading =
+    networkStatus === NetworkStatus.loading ||
+    networkStatus === NetworkStatus.setVariables;
+
+  const scheduleSettleRefetch = useCallback(() => {
+    if (settleTimer.current) {
+      clearTimeout(settleTimer.current);
+    }
+    settleTimer.current = setTimeout(() => {
+      refetch();
+      settleTimer.current = null;
+    }, SETTLE_REFETCH_MS);
+  }, [refetch]);
+
+  const [addToCart, { loading: addLoading }] = useMutation(ADD_TO_CART, {
+    onCompleted: scheduleSettleRefetch,
+  });
+
+  const [updateCart, { loading: updateLoading }] = useMutation(UPDATE_CART, {
+    onCompleted: () => {
+      refetch();
+      scheduleSettleRefetch();
+    },
+  });
+
+  const addItem = useCallback(
+    (productId: number, variationId?: number) => {
+      addToCart({
+        variables: {
+          input: {
+            clientMutationId: uuidv4(),
+            productId,
+            ...(variationId ? { variationId } : {}),
+          },
+        },
+      });
+    },
+    [addToCart],
+  );
+
+  const setQuantity = useCallback(
+    (cartKey: string, quantity: number) => {
+      const nodes: ICartItemNode[] = data?.cart?.contents?.nodes ?? [];
+      if (!nodes.length) {
+        return;
+      }
+      updateCart({
+        variables: {
+          input: {
+            clientMutationId: uuidv4(),
+            items: getUpdatedItems(nodes, quantity, cartKey),
+          },
+        },
+      });
+    },
+    [data, updateCart],
+  );
+
+  const removeItem = useCallback(
+    (cartKey: string) => setQuantity(cartKey, 0),
+    [setQuantity],
+  );
+
+  // Reconcile with WooCommerce on mount.
+  useEffect(() => {
+    refetch();
+  }, [refetch]);
+
+  // Clear any pending settle timer on unmount.
+  useEffect(
+    () => () => {
+      if (settleTimer.current) {
+        clearTimeout(settleTimer.current);
+      }
+    },
+    [],
+  );
+
+  return {
+    cart,
+    isLoading,
+    isUpdating: addLoading || updateLoading,
+    error,
+    addItem,
+    setQuantity,
+    removeItem,
+    refetchCart: refetch,
+  };
+};
+
+export default useCart;

--- a/src/hooks/useCart.ts
+++ b/src/hooks/useCart.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef } from 'react';
+import { useCallback, useEffect } from 'react';
 import {
   NetworkStatus,
   useMutation,
@@ -19,21 +19,18 @@ import { getFormattedCart, getUpdatedItems } from './cart/cartUtils';
 
 // Types
 import type { Cart } from '@/types/cart';
-import type { ICartItemNode, IFormattedCartProps } from '@/types/graphql';
-
-/**
- * How long to wait before the reconciling refetch fires. WooCommerce needs a
- * moment for the session/cart to settle after a mutation; a single source of
- * truth for this delay replaces the 2s/3s copies scattered across components.
- */
-const SETTLE_REFETCH_MS = 2000;
+import type {
+  IAddToCartData,
+  IUpdateCartData,
+  IFormattedCartProps,
+} from '@/types/graphql';
 
 export interface UseCartResult {
   /** Formatted, client-side cart. Null when empty or not yet loaded. */
   cart: Cart | null;
   /** True until the first GET_CART for this mount has settled. */
   isLoading: boolean;
-  /** True while an add/update/remove mutation (or its settle refetch) is in flight. */
+  /** True while an add/update/remove mutation is in flight. */
   isUpdating: boolean;
   /** Set if the cart query failed. */
   error?: ApolloError;
@@ -50,10 +47,16 @@ export interface UseCartResult {
 /**
  * The Cart module's single public interface.
  *
- * Owns the entire fetch → format → sync → settle-refetch ritual that used to be
- * copy-pasted across CartInitializer, CartContents, AddToCart and CheckoutForm.
- * Query, mutations, formatting, the settle-refetch hack, store sync and
- * empty-cart session clearing are all implementation details behind this hook.
+ * Owns the entire fetch → format → sync ritual that used to be copy-pasted
+ * across CartInitializer, CartContents, AddToCart and CheckoutForm. Query,
+ * mutations, formatting, store sync and empty-cart session clearing are all
+ * implementation details behind this hook.
+ *
+ * The mutations return the whole authoritative cart (the same selection as
+ * GET_CART, via the shared CartFields fragment), so `onCompleted` formats that
+ * response and writes it straight to the store. There is no settle-refetch and
+ * no timer: the server's own mutation reply is the source of truth, which also
+ * removes the race that the old `setTimeout(refetch)` hack papered over.
  *
  * Rendering reads the persisted store `cart` (so the UI never flashes empty on
  * hydration); decisions that could destroy the session — showing the empty
@@ -65,54 +68,52 @@ export const useCart = (): UseCartResult => {
   const replace = useCartStore((state) => state.replace);
   const clear = useCartStore((state) => state.clear);
 
-  // Track pending settle-refetch timers so they can be cleared on unmount.
-  const settleTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  const {
-    data,
-    error,
-    refetch,
-    networkStatus,
-  } = useQuery<IFormattedCartProps>(GET_CART, {
-    notifyOnNetworkStatusChange: true,
-    onCompleted: (completed) => {
-      const formatted = getFormattedCart(completed);
-      if (!formatted && !completed?.cart?.contents?.nodes?.length) {
-        // Cart is genuinely empty after a settled fetch — clear the session.
-        clear();
-        return;
-      }
+  /**
+   * Reconcile a cart payload (from the query or a mutation) with the store:
+   * write the formatted cart when there are contents, clear the session when it
+   * has genuinely emptied.
+   */
+  const syncFromServer = useCallback(
+    (payload: IFormattedCartProps | null | undefined) => {
+      const formatted = getFormattedCart(payload ?? undefined);
       if (formatted) {
         replace(formatted);
+        return;
+      }
+      // No contents in a settled server response — the cart is truly empty.
+      if (!payload?.cart?.contents?.nodes?.length) {
+        clear();
       }
     },
-  });
+    [replace, clear],
+  );
+
+  const { error, refetch, networkStatus } = useQuery<IFormattedCartProps>(
+    GET_CART,
+    {
+      notifyOnNetworkStatusChange: true,
+      onCompleted: syncFromServer,
+    },
+  );
 
   // isLoading is true only until the first fetch settles for this mount.
   const isLoading =
     networkStatus === NetworkStatus.loading ||
     networkStatus === NetworkStatus.setVariables;
 
-  const scheduleSettleRefetch = useCallback(() => {
-    if (settleTimer.current) {
-      clearTimeout(settleTimer.current);
-    }
-    settleTimer.current = setTimeout(() => {
-      refetch();
-      settleTimer.current = null;
-    }, SETTLE_REFETCH_MS);
-  }, [refetch]);
-
-  const [addToCart, { loading: addLoading }] = useMutation(ADD_TO_CART, {
-    onCompleted: scheduleSettleRefetch,
-  });
-
-  const [updateCart, { loading: updateLoading }] = useMutation(UPDATE_CART, {
-    onCompleted: () => {
-      refetch();
-      scheduleSettleRefetch();
+  const [addToCart, { loading: addLoading }] = useMutation<IAddToCartData>(
+    ADD_TO_CART,
+    {
+      onCompleted: (result) => syncFromServer(result?.addToCart),
     },
-  });
+  );
+
+  const [updateCart, { loading: updateLoading }] = useMutation<IUpdateCartData>(
+    UPDATE_CART,
+    {
+      onCompleted: (result) => syncFromServer(result?.updateItemQuantities),
+    },
+  );
 
   const addItem = useCallback(
     (productId: number, variationId?: number) => {
@@ -131,20 +132,22 @@ export const useCart = (): UseCartResult => {
 
   const setQuantity = useCallback(
     (cartKey: string, quantity: number) => {
-      const nodes: ICartItemNode[] = data?.cart?.contents?.nodes ?? [];
-      if (!nodes.length) {
+      // Derive the update from the same store cart the UI renders from, so the
+      // mutation input can never disagree with what the user sees.
+      const products = cart?.products ?? [];
+      if (!products.length) {
         return;
       }
       updateCart({
         variables: {
           input: {
             clientMutationId: uuidv4(),
-            items: getUpdatedItems(nodes, quantity, cartKey),
+            items: getUpdatedItems(products, quantity, cartKey),
           },
         },
       });
     },
-    [data, updateCart],
+    [cart, updateCart],
   );
 
   const removeItem = useCallback(
@@ -156,16 +159,6 @@ export const useCart = (): UseCartResult => {
   useEffect(() => {
     refetch();
   }, [refetch]);
-
-  // Clear any pending settle timer on unmount.
-  useEffect(
-    () => () => {
-      if (settleTimer.current) {
-        clearTimeout(settleTimer.current);
-      }
-    },
-    [],
-  );
 
   return {
     cart,

--- a/src/stores/cartStore.ts
+++ b/src/stores/cartStore.ts
@@ -11,29 +11,21 @@ const WOO_SESSION_KEY = 'woo-session:v1';
 
 interface CartState {
   cart: Cart | null;
-  isLoading: boolean;
-  setCart: (cart: CartState['cart']) => void;
-  updateCart: (newCart: NonNullable<CartState['cart']>) => void;
-  syncWithWooCommerce: (cart: NonNullable<CartState['cart']>) => void;
-  clearWooCommerceSession: () => void;
+  /** Replace the cart with a server-confirmed value and mirror it to storage. */
+  replace: (cart: NonNullable<CartState['cart']>) => void;
+  /** Clear the cart and the WooCommerce session keys. */
+  clear: () => void;
 }
 
 export const useCartStore = create<CartState>()(
   persist(
     (set) => ({
       cart: null,
-      isLoading: false,
-      setCart: (cart) => set({ cart }),
-      updateCart: (newCart) => {
-        set({ cart: newCart });
-        // Sync with WooCommerce
-        localStorage.setItem(WOOCOMMERCE_CART_KEY, JSON.stringify(newCart));
-      },
-      syncWithWooCommerce: (cart) => {
+      replace: (cart) => {
         set({ cart });
         localStorage.setItem(WOOCOMMERCE_CART_KEY, JSON.stringify(cart));
       },
-      clearWooCommerceSession: () => {
+      clear: () => {
         set({ cart: null });
         localStorage.removeItem(WOO_SESSION_KEY);
         localStorage.removeItem(WOOCOMMERCE_CART_KEY);

--- a/src/types/graphql.ts
+++ b/src/types/graphql.ts
@@ -111,3 +111,19 @@ export interface IUpdateCartMutationArgs {
 export interface IFormattedCartProps {
   cart: { contents: { nodes: ICartItemNode[] }; total: number };
 }
+
+/**
+ * ADD_TO_CART now returns the whole authoritative cart (same selection as
+ * GET_CART) so the client can trust the mutation response and skip a refetch.
+ */
+export interface IAddToCartData {
+  addToCart: IFormattedCartProps | null;
+}
+
+/**
+ * UPDATE_CART likewise returns the whole authoritative cart, letting quantity
+ * changes and removals update the store from the mutation response alone.
+ */
+export interface IUpdateCartData {
+  updateItemQuantities: IFormattedCartProps | null;
+}

--- a/src/utils/functions/functions.tsx
+++ b/src/utils/functions/functions.tsx
@@ -1,36 +1,12 @@
-/*eslint complexity: ["error", 20]*/
-
 import { v4 as uuidv4 } from 'uuid';
-import { ChangeEvent } from 'react';
 
-import type { CartProduct, Cart } from '@/types/cart';
 import type { ICheckoutDataProps } from '@/types/checkout';
-import type {
-  ICartItemNode,
-  IUpdateCartMutationArgs,
-  IFormattedCartProps,
-} from '@/types/graphql';
-
-// Re-export types that other files import from here
-export type { ICartItemNode } from '@/types/graphql';
-export type { ICheckoutDataProps } from '@/types/checkout';
-export type { IUpdateCartItem } from '@/types/graphql';
-export type { IUpdateCartInput } from '@/types/graphql';
-export type { IUpdateCartVariables } from '@/types/graphql';
-export type { IUpdateCartMutationArgs } from '@/types/graphql';
-
-// Keep backward-compatible alias for IProductRootObject → ICartItemNode
-export type IProductRootObject = ICartItemNode;
-export type IUpdateCartRootObject = IUpdateCartMutationArgs;
-
-type TUpdatedItems = { key: string; quantity: number }[];
 
 /**
  * Add empty character after currency symbol
  * @param {string} price The price string that we input
  * @param {string} symbol Currency symbol to add empty character/padding after
  */
-
 export const paddedPrice = (price: string, symbol: string) =>
   price.split(symbol).join(`${symbol} `);
 
@@ -61,62 +37,8 @@ export const filteredVariantPrice = (price: string, side: string) => {
 };
 
 /**
- * Returns cart data in the required format.
- * @param {IFormattedCartProps} data Cart data from GraphQL
+ * Build the input payload for the checkout mutation from the billing form data.
  */
-
-export const getFormattedCart = (data: IFormattedCartProps) => {
-  if (!data?.cart?.contents?.nodes?.length) {
-    return;
-  }
-
-  const givenProducts = data.cart.contents.nodes;
-
-  const formattedCart: Cart = {
-    products: [],
-    totalProductsCount: 0,
-    totalProductsPrice: 0,
-  };
-
-  let totalProductsCount = 0;
-
-  givenProducts.forEach((item) => {
-    const givenProduct = item.product.node;
-
-    // Convert price to a float value
-    const convertedCurrency = item.total.replace(/[^0-9.-]+/g, '');
-
-    // Create a new product object for each item to avoid shared reference bug
-    const product: CartProduct = {
-      productId: givenProduct.productId,
-      cartKey: item.key,
-      name: givenProduct.name,
-      qty: item.quantity,
-      price: Number(convertedCurrency) / item.quantity,
-      totalPrice: item.total,
-      image: givenProduct.image?.sourceUrl
-        ? {
-            sourceUrl: givenProduct.image.sourceUrl,
-            srcSet: givenProduct.image.srcSet,
-            title: givenProduct.image.title,
-          }
-        : {
-            sourceUrl: process.env.NEXT_PUBLIC_PLACEHOLDER_SMALL_IMAGE_URL,
-            srcSet: process.env.NEXT_PUBLIC_PLACEHOLDER_SMALL_IMAGE_URL,
-            title: givenProduct.name,
-          },
-    };
-
-    totalProductsCount += item.quantity;
-    formattedCart.products.push(product);
-  });
-
-  formattedCart.totalProductsCount = totalProductsCount;
-  formattedCart.totalProductsPrice = data.cart.total;
-
-  return formattedCart;
-};
-
 export const createCheckoutData = (order: ICheckoutDataProps) => ({
   clientMutationId: uuidv4(),
   billing: {
@@ -150,59 +72,3 @@ export const createCheckoutData = (order: ICheckoutDataProps) => ({
   isPaid: false,
   transactionId: uuidv4(),
 });
-
-/**
- * Get the updated items in the below format required for mutation input.
- *
- * Creates an array in above format with the newQty (updated Qty ).
- *
- */
-export const getUpdatedItems = (
-  products: ICartItemNode[],
-  newQty: number,
-  cartKey: string,
-) => {
-  const updatedItems: TUpdatedItems = products.map((cartItem) => ({
-    key: cartItem.key,
-    quantity: cartItem.key === cartKey ? newQty : cartItem.quantity,
-  }));
-
-  return updatedItems;
-};
-
-/*
- * When user changes the quantity, update the cart in localStorage
- * Also update the cart in the global Context
- */
-export const handleQuantityChange = (
-  event: ChangeEvent<HTMLInputElement>,
-  cartKey: string,
-  cart: ICartItemNode[],
-  updateCart: (variables: IUpdateCartMutationArgs) => void,
-  updateCartProcessing: boolean,
-) => {
-  if (typeof window !== 'undefined') {
-    event.stopPropagation();
-
-    // Return if the previous update cart mutation request is still processing
-    if (updateCartProcessing || !cart) {
-      return;
-    }
-
-    // If the user tries to delete the count of product, set that to 1 by default ( This will not allow him to reduce it less than zero )
-    const newQty = event.target.value ? parseInt(event.target.value, 10) : 1;
-
-    if (cart.length) {
-      const updatedItems = getUpdatedItems(cart, newQty, cartKey);
-
-      updateCart({
-        variables: {
-          input: {
-            clientMutationId: uuidv4(),
-            items: updatedItems,
-          },
-        },
-      });
-    }
-  }
-};

--- a/src/utils/gql/GQL_MUTATIONS.ts
+++ b/src/utils/gql/GQL_MUTATIONS.ts
@@ -1,5 +1,7 @@
 import { gql } from '@apollo/client';
 
+import { CART_FIELDS } from './GQL_QUERIES';
+
 export const LOGIN_USER = gql`
   mutation Login($username: String!, $password: String!) {
     loginWithCookies(input: { login: $username, password: $password }) {
@@ -12,66 +14,12 @@ export const LOGIN_USER = gql`
 export const ADD_TO_CART = gql`
   mutation ($input: AddToCartInput!) {
     addToCart(input: $input) {
-      cartItem {
-        key
-        product {
-          node {
-            id
-            databaseId
-            name
-            description
-            type
-            onSale
-            slug
-            averageRating
-            reviewCount
-            image {
-              id
-              sourceUrl
-              altText
-            }
-            galleryImages {
-              nodes {
-                id
-                sourceUrl
-                altText
-              }
-            }
-          }
-        }
-        variation {
-          node {
-            id
-            databaseId
-            name
-            description
-            type
-            onSale
-            price
-            regularPrice
-            salePrice
-            image {
-              id
-              sourceUrl
-              altText
-            }
-            attributes {
-              nodes {
-                id
-                attributeId
-                name
-                value
-              }
-            }
-          }
-        }
-        quantity
-        total
-        subtotal
-        subtotalTax
+      cart {
+        ...CartFields
       }
     }
   }
+  ${CART_FIELDS}
 `;
 
 export const CHECKOUT_MUTATION = gql`
@@ -85,96 +33,10 @@ export const CHECKOUT_MUTATION = gql`
 export const UPDATE_CART = gql`
   mutation ($input: UpdateItemQuantitiesInput!) {
     updateItemQuantities(input: $input) {
-      items {
-        key
-        product {
-          node {
-            id
-            databaseId
-            name
-            description
-            type
-            onSale
-            slug
-            averageRating
-            reviewCount
-            image {
-              id
-              sourceUrl
-              altText
-            }
-            galleryImages {
-              nodes {
-                id
-                sourceUrl
-                altText
-              }
-            }
-          }
-        }
-
-        variation {
-          node {
-            id
-            databaseId
-            name
-            description
-            type
-            onSale
-            price
-            regularPrice
-            salePrice
-            image {
-              id
-              sourceUrl
-              altText
-            }
-            attributes {
-              nodes {
-                id
-                attributeId
-                name
-                value
-              }
-            }
-          }
-        }
-        quantity
-        total
-        subtotal
-        subtotalTax
-      }
-      removed {
-        key
-        product {
-          node {
-            id
-            databaseId
-          }
-        }
-        variation {
-          node {
-            id
-            databaseId
-          }
-        }
-      }
-      updated {
-        key
-        product {
-          node {
-            id
-            databaseId
-          }
-        }
-
-        variation {
-          node {
-            id
-            databaseId
-          }
-        }
+      cart {
+        ...CartFields
       }
     }
   }
+  ${CART_FIELDS}
 `;

--- a/src/utils/gql/GQL_QUERIES.ts
+++ b/src/utils/gql/GQL_QUERIES.ts
@@ -212,87 +212,102 @@ export const GET_PRODUCTS_FROM_CATEGORY = gql`
   }
 `;
 
+/**
+ * Shared cart selection.
+ *
+ * Reused by GET_CART and by the ADD_TO_CART / UPDATE_CART mutations so that the
+ * cart a mutation returns is byte-for-byte the same shape the query returns.
+ * That parity is what lets the Cart module trust a mutation's own response and
+ * skip the old settle-refetch entirely.
+ */
+export const CART_FIELDS = gql`
+  fragment CartFields on Cart {
+    contents {
+      nodes {
+        key
+        product {
+          node {
+            id
+            databaseId
+            name
+            description
+            type
+            onSale
+            slug
+            averageRating
+            reviewCount
+            image {
+              id
+              sourceUrl
+              srcSet
+              altText
+              title
+            }
+            galleryImages {
+              nodes {
+                id
+                sourceUrl
+                srcSet
+                altText
+                title
+              }
+            }
+          }
+        }
+        variation {
+          node {
+            id
+            databaseId
+            name
+            description
+            type
+            onSale
+            price
+            regularPrice
+            salePrice
+            image {
+              id
+              sourceUrl
+              srcSet
+              altText
+              title
+            }
+            attributes {
+              nodes {
+                id
+                name
+                value
+              }
+            }
+          }
+        }
+        quantity
+        total
+        subtotal
+        subtotalTax
+      }
+    }
+
+    subtotal
+    subtotalTax
+    shippingTax
+    shippingTotal
+    total
+    totalTax
+    feeTax
+    feeTotal
+    discountTax
+    discountTotal
+  }
+`;
+
 export const GET_CART = gql`
   query GET_CART {
     cart {
-      contents {
-        nodes {
-          key
-          product {
-            node {
-              id
-              databaseId
-              name
-              description
-              type
-              onSale
-              slug
-              averageRating
-              reviewCount
-              image {
-                id
-                sourceUrl
-                srcSet
-                altText
-                title
-              }
-              galleryImages {
-                nodes {
-                  id
-                  sourceUrl
-                  srcSet
-                  altText
-                  title
-                }
-              }
-            }
-          }
-          variation {
-            node {
-              id
-              databaseId
-              name
-              description
-              type
-              onSale
-              price
-              regularPrice
-              salePrice
-              image {
-                id
-                sourceUrl
-                srcSet
-                altText
-                title
-              }
-              attributes {
-                nodes {
-                  id
-                  name
-                  value
-                }
-              }
-            }
-          }
-          quantity
-          total
-          subtotal
-          subtotalTax
-        }
-      }
-
-      subtotal
-      subtotalTax
-      shippingTax
-      shippingTotal
-      total
-      totalTax
-      feeTax
-      feeTotal
-      discountTax
-      discountTotal
+      ...CartFields
     }
   }
+  ${CART_FIELDS}
 `;
 
 export const GET_CURRENT_USER = gql`


### PR DESCRIPTION
- This commit introduces a shared useCart hook to own WooCommerce cart fetching, formatting, syncing, and mutation flows. Components now read from the cart store via the hook instead of duplicating GET_CART/UPDATE_CART logic, and the cart store API is simplified to replace and clear cart state. It also removes legacy cart formatting helpers from the utility module and keeps empty-cart handling consistent across cart, product, and checkout views.