### PR TITLE
Treat empty cart reads as non-destructive

### DIFF
--- a/src/hooks/useCart.ts
+++ b/src/hooks/useCart.ts
@@ -69,19 +69,30 @@ export const useCart = (): UseCartResult => {
   const clear = useCartStore((state) => state.clear);
 
   /**
-   * Reconcile a cart payload (from the query or a mutation) with the store:
-   * write the formatted cart when there are contents, clear the session when it
-   * has genuinely emptied.
+   * Reconcile a cart payload with the store.
+   *
+   * `allowClear` distinguishes the two callers, which have different authority
+   * over "empty":
+   *
+   * - **Query (`allowClear = false`, populate-only):** a GET_CART fired on mount
+   *   can race the WooCommerce session and come back empty before the session
+   *   has propagated. An empty *read* is therefore NOT proof the cart is empty,
+   *   so it must never destroy state — it simply has nothing to populate. (This
+   *   is the race the old `setTimeout(refetch)` hack papered over.)
+   * - **Mutation (`allowClear = true`, authoritative):** an add/update/remove
+   *   reply reflects a write the user just made. An empty cart here is a real
+   *   "the last item was removed" signal, so clearing is correct.
    */
   const syncFromServer = useCallback(
-    (payload: IFormattedCartProps | null | undefined) => {
+    (payload: IFormattedCartProps | null | undefined, allowClear: boolean) => {
       const formatted = getFormattedCart(payload ?? undefined);
       if (formatted) {
         replace(formatted);
         return;
       }
-      // No contents in a settled server response — the cart is truly empty.
-      if (!payload?.cart?.contents?.nodes?.length) {
+      // Only a confirmed-empty mutation reply may clear the cart. An empty read
+      // is ignored so a session race can never wipe a populated cart.
+      if (allowClear && !payload?.cart?.contents?.nodes?.length) {
         clear();
       }
     },
@@ -92,7 +103,8 @@ export const useCart = (): UseCartResult => {
     GET_CART,
     {
       notifyOnNetworkStatusChange: true,
-      onCompleted: syncFromServer,
+      // Query results are populate-only: never clear on an empty read.
+      onCompleted: (data) => syncFromServer(data, false),
     },
   );
 
@@ -104,14 +116,16 @@ export const useCart = (): UseCartResult => {
   const [addToCart, { loading: addLoading }] = useMutation<IAddToCartData>(
     ADD_TO_CART,
     {
-      onCompleted: (result) => syncFromServer(result?.addToCart),
+      // Mutation reply is authoritative: allow it to clear a confirmed-empty cart.
+      onCompleted: (result) => syncFromServer(result?.addToCart, true),
     },
   );
 
   const [updateCart, { loading: updateLoading }] = useMutation<IUpdateCartData>(
     UPDATE_CART,
     {
-      onCompleted: (result) => syncFromServer(result?.updateItemQuantities),
+      // Mutation reply is authoritative (this is how removeItem empties the cart).
+      onCompleted: (result) => syncFromServer(result?.updateItemQuantities, true),
     },
   );
 

--- a/src/stores/cartStore.ts
+++ b/src/stores/cartStore.ts
@@ -5,15 +5,22 @@ import type { Cart } from '@/types/cart';
 
 export type { Cart } from '@/types/cart';
 
-// Versioned localStorage keys to prevent crashes on schema changes
+// Versioned localStorage key to prevent crashes on schema changes
 const WOOCOMMERCE_CART_KEY = 'woocommerce-cart:v1';
-const WOO_SESSION_KEY = 'woo-session:v1';
 
 interface CartState {
   cart: Cart | null;
   /** Replace the cart with a server-confirmed value and mirror it to storage. */
   replace: (cart: NonNullable<CartState['cart']>) => void;
-  /** Clear the cart and the WooCommerce session keys. */
+  /**
+   * Empty the displayed cart and its storage mirror.
+   *
+   * Deliberately does NOT touch the WooCommerce session token: emptying the
+   * cart (e.g. removing the last line item, or a completed order) must not
+   * destroy the session, otherwise every subsequent request is session-less
+   * and the cart can never be rebuilt. Session lifetime is owned by the Apollo
+   * link (7-day expiry) — see ApolloClient.ts.
+   */
   clear: () => void;
 }
 
@@ -27,7 +34,6 @@ export const useCartStore = create<CartState>()(
       },
       clear: () => {
         set({ cart: null });
-        localStorage.removeItem(WOO_SESSION_KEY);
         localStorage.removeItem(WOOCOMMERCE_CART_KEY);
       },
     }),


### PR DESCRIPTION
Add an allowClear flag to syncFromServer so GET_CART query results never clear the local cart (avoids session-read races), while mutation replies remain authoritative and may clear an empty cart. Update onCompleted handlers to pass false for queries and true for mutations. Update cart store clear() to stop removing the WooCommerce session token (remove unused WOO_SESSION_KEY); session lifetime is handled by the Apollo link.