### PR TITLE
Clear cart after checkout completion

### DIFF
--- a/src/components/Checkout/CheckoutForm.component.tsx
+++ b/src/components/Checkout/CheckoutForm.component.tsx
@@ -20,7 +20,7 @@ import { createCheckoutData } from '@/utils/functions/functions';
 import type { ICheckoutDataProps } from '@/types/checkout';
 
 const CheckoutForm = () => {
-  const { cart, isLoading, refetchCart } = useCart();
+  const { cart, isLoading, refetchCart, clearCart } = useCart();
   const [requestError, setRequestError] = useState<ApolloError | null>(null);
   const [orderCompleted, setorderCompleted] = useState<boolean>(false);
 
@@ -30,7 +30,9 @@ const CheckoutForm = () => {
     {
       onCompleted: () => {
         setorderCompleted(true);
-        refetchCart();
+        // The order emptied the server cart out-of-band. A refetch would be
+        // ignored by the populate-only query path, so clear explicitly.
+        clearCart();
       },
       onError: (error) => {
         setRequestError(error);

--- a/src/hooks/useCart.ts
+++ b/src/hooks/useCart.ts
@@ -42,6 +42,12 @@ export interface UseCartResult {
   removeItem: (cartKey: string) => void;
   /** Force a re-read of the cart from WooCommerce. */
   refetchCart: () => void;
+  /**
+   * Explicitly empty the cart client-side. Use after an event that empties the
+   * server cart out-of-band (e.g. a completed checkout), where a refetch would
+   * be ignored by the populate-only query path.
+   */
+  clearCart: () => void;
 }
 
 /**
@@ -183,6 +189,7 @@ export const useCart = (): UseCartResult => {
     setQuantity,
     removeItem,
     refetchCart: refetch,
+    clearCart: clear,
   };
 };
 


### PR DESCRIPTION
- Successful checkout was leaving the client cart state stale because the server emptied the cart out-of-band. This change clears the cart immediately after order completion instead of relying on a refetch that is ignored by the populate-only query path.