### PR TITLE
Remove checkout ESLint override

### DIFF
--- a/src/components/Checkout/CheckoutForm.component.tsx
+++ b/src/components/Checkout/CheckoutForm.component.tsx
@@ -1,4 +1,3 @@
-/*eslint complexity: ["error", 20]*/
 // Imports
 import { useState, useEffect } from 'react';
 import { useQuery, useMutation, ApolloError } from '@apollo/client';


### PR DESCRIPTION
This change removes the file-level ESLint complexity exception from the checkout form component. The component will now be validated against the default complexity rule instead of bypassing it with a local override.