### PR TITLE
Enable TypeScript CLI in Next config

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -2,6 +2,9 @@ import type { NextConfig } from 'next';
 
 const nextConfig: NextConfig = {
   reactStrictMode: true,
+  experimental: {
+    useTypeScriptCli: true,
+  },
   images: {
     remotePatterns: [
       {


### PR DESCRIPTION
- This change adds the experimental `useTypeScriptCli` flag to the Next.js configuration so TypeScript-based CLI support is enabled during local builds and tooling.
- Needed for Typescript 7 support